### PR TITLE
Change RxJS to peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rxfm",
-  "version": "0.0.1",
+  "version": "1.0.0-alpha.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12263,6 +12263,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -13709,7 +13710,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tslint": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxfm",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "author": "Alden Laslett",
   "description": "A Web Framework Built on RxJS",
   "license": "MIT",
@@ -9,6 +9,16 @@
     "url": "git+https://github.com/alden12/rxfm.git"
   },
   "homepage": "https://github.com/alden12/rxfm",
+  "keywords": [
+    "RxJS",
+    "Rx",
+    "observable",
+    "web",
+    "framework",
+    "reactive",
+    "functional",
+    "frontend"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -21,8 +31,8 @@
     "test": "jest",
     "test:watch": "jest --watch"
   },
-  "dependencies": {
-    "rxjs": "6.5.2"
+  "peerDependencies": {
+    "rxjs": "^6.5.2"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",


### PR DESCRIPTION
Changed rxjs to peer dependency, added caret to rxjs version, added keywords to package, incremented package version to 1.0.0-alpha.8