### PR TITLE
Simplify mapToComponents operator function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2021-09-26
+## [2.0.0] - 2021-11-26
 
 ### Added
 - Added generic `switchTap` operator to inject an observable side effect into the stream.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added generic `switchTap` operator to inject an observable side effect into the stream.
 
 ### Changed
-- Reversed order of `mapToComponents` arguments.
+- Reversed order of `mapToComponents` arguments. Made item index the default id if no id function is provided. Added ability to pass an item key name to derive id from.
 - Changed names of `notGate`, `andGate`, `nandGate`, `orGate` and `norGate` observable boolean logic functions to `not`, `and`, `nand`, `or` and `nor` respectively.
 
 ## [1.0.0-beta.1] - 2021-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2021-09-26
 
+### Added
+- Added generic `switchTap` operator to inject an observable side effect into the stream.
+
 ### Changed
 - Reversed order of `mapToComponents` arguments.
-- Changed names of `notGate`, `andGate`, `nandGate`, `orGate` and `norGate` to `not`, `and`, `nand`, `or` and `nor` respectively.
+- Changed names of `notGate`, `andGate`, `nandGate`, `orGate` and `norGate` observable boolean logic functions to `not`, `and`, `nand`, `or` and `nor` respectively.
 
 ## [1.0.0-beta.1] - 2021-07-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.0] - 2021-09-26
+### Added
+- 
+
+### Changed
+- Reversed order of mapToComponents arguments.
+
 ## [1.0.0-beta.1] - 2021-07-08
 ### Added
 - Added proxies to access individual style, attribute, and event operators as properties of their respective operators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0-alpha.0] - 2021-09-26
-### Added
-- 
+## [2.0.0] - 2021-09-26
 
 ### Changed
-- Reversed order of mapToComponents arguments.
+- Reversed order of `mapToComponents` arguments.
+- Changed names of `notGate`, `andGate`, `nandGate`, `orGate` and `norGate` to `not`, `and`, `nand`, `or` and `nor` respectively.
 
 ## [1.0.0-beta.1] - 2021-07-08
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxfm",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0",
   "author": "Alden Laslett",
   "description": "A Web Framework Built on RxJS",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxfm",
-  "version": "1.0.0-beta.1",
+  "version": "2.0.0-alpha.0",
   "author": "Alden Laslett",
   "description": "A Web Framework Built on RxJS",
   "license": "MIT",

--- a/src/app/advanced-examples/minesweeper/components/game-board.ts
+++ b/src/app/advanced-examples/minesweeper/components/game-board.ts
@@ -14,10 +14,7 @@ interface GameBoardProps {
 export const GameBoard = ({ board, dispatch }: GameBoardProps) => Div(
   board.pipe(
     map(flatten),
-    mapToComponents(
-      (_, index) => index,
-      (cell, index) => GameCell({ cell, index, dispatch }),
-    ),
+    mapToComponents((cell, index) => GameCell({ cell, index, dispatch })),
   ),
 ).pipe(
   event.contextmenu(ev => ev.preventDefault()),

--- a/src/app/advanced-examples/minesweeper/components/game-cell.ts
+++ b/src/app/advanced-examples/minesweeper/components/game-cell.ts
@@ -1,4 +1,4 @@
-import { destructure, Div, conditional, andGate, styles, classes, events, access } from "rxfm";
+import { destructure, Div, conditional, and, styles, classes, events, access } from "rxfm";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { indexToVector, NEIGHBORS_COLOR_MAP } from "../constants";
@@ -19,7 +19,7 @@ export const GameCell = ({ cell, index, dispatch }: GameCellProps) => {
   );
 
   const cellText = conditional({
-    if: andGate(isCleared, hasNeighbors),
+    if: and(isCleared, hasNeighbors),
     then: neighbors,
     else: symbol,
   });

--- a/src/app/advanced-examples/snake-game/snake-game.ts
+++ b/src/app/advanced-examples/snake-game/snake-game.ts
@@ -15,7 +15,7 @@ const GameCell = (cellType: Observable<SnakeCell>) => Div().pipe(
 const GameBoard = (board: Observable<SnakeBoard>) => Div(
   board.pipe(
     map(flatten),
-    mapToComponents((_, i) => i, GameCell),
+    mapToComponents(GameCell),
   ),
 ).pipe(
   classes`snake-game-board`,

--- a/src/app/advanced-examples/todo-list/todo-list.ts
+++ b/src/app/advanced-examples/todo-list/todo-list.ts
@@ -48,10 +48,7 @@ export const TodoList = () => {
   );
 
   const TodoItems = items.pipe(
-    mapToComponents(
-      ({ name }) => name,
-      item => TodoItem(item, toggleItem),
-    ),
+    mapToComponents(item => TodoItem(item, toggleItem), 'name'),
   );
 
   return Div(

--- a/src/app/basic-examples/dynamic-component-arrays.ts
+++ b/src/app/basic-examples/dynamic-component-arrays.ts
@@ -21,7 +21,7 @@ export const ComponentArraysExample = () => {
   );
 
   const ItemComponents = items.pipe(
-    mapToComponents(item => item.name, Item),
+    mapToComponents(Item, 'name'),
   );
 
   return Div(ItemComponents);

--- a/src/lib/rxfm/attributes/attribute-operator-isolation.ts
+++ b/src/lib/rxfm/attributes/attribute-operator-isolation.ts
@@ -75,7 +75,7 @@ export function setAttributes<K extends string, T>(
       Object.keys(previousAttributeObject).reduce((prevAttributesEmpty, key) => {
         prevAttributesEmpty[key as K] = null;
         return prevAttributesEmpty;
-      }, {} as Partial<Record<K, null>>)
+      }, {} as Partial<Record<K, null>>);
     // Merge the previous attributes object with null keys with the one, any removed keys will now have null values.
     attributeObjectWithDeletions = { ...previousAttributeObjectNulled, ...attributeObject };
   }

--- a/src/lib/rxfm/components/component.ts
+++ b/src/lib/rxfm/components/component.ts
@@ -1,7 +1,7 @@
 import { defer, MonoTypeOperatorFunction, Observable, of } from "rxjs";
-import { switchMap, startWith, distinctUntilChanged, tap, ignoreElements } from "rxjs/operators";
+import { tap } from "rxjs/operators";
 import { children, ComponentChild } from "../children/children";
-import { flatten } from "../utils";
+import { flatten, switchTap } from "../utils";
 
 /**
  * The possible DOM element types which can be used in RxFM. These are HTML and SVG elements.
@@ -76,14 +76,7 @@ export function componentCreator<T extends ElementType>(componentFunction: Compo
 export function componentOperator<T extends ElementType, U>(
   effect: (element: T) => Observable<U>,
 ): ComponentOperator<T> {
-  return (component: Component<T>) => component.pipe(
-    distinctUntilChanged(),
-    switchMap(element => effect(element).pipe( // Add the effect observable into the stream.
-      ignoreElements(), // Ignore the effect observable's emissions.
-      startWith(element), // Return the original element as a single emission.
-    )),
-    distinctUntilChanged(),
-  );
+  return switchTap<T, U>(effect);
 }
 
 /**

--- a/src/lib/rxfm/map-to-components.ts
+++ b/src/lib/rxfm/map-to-components.ts
@@ -144,7 +144,7 @@ export function mapToComponents<I, T extends ElementType>(
 ): OperatorFunction<I[], ElementType[]>;
 export function mapToComponents<I, T extends ElementType>(
   creationFunction: (item: Observable<I>, index: Observable<number>) => Component<T>,
-  keyProp: KeysOfValue<I, Id>,
+  idProp: KeysOfValue<I, Id>,
 ): OperatorFunction<I[], ElementType[]>;
 export function mapToComponents<I, T extends ElementType>(
   creationFunction: (item: Observable<I>, index: Observable<number>) => Component<T>,

--- a/src/lib/rxfm/map-to-components.ts
+++ b/src/lib/rxfm/map-to-components.ts
@@ -1,7 +1,7 @@
 import { Observable, OperatorFunction, from, of } from 'rxjs';
 import { ElementType, Component } from './components';
 import { map, filter, startWith, mergeAll, distinctUntilChanged, switchMap, takeUntil, tap, shareReplay } from 'rxjs/operators';
-import { selectFrom } from './utils';
+import { KeysOfValue, selectFrom } from './utils';
 
 type Id = string | number;
 
@@ -127,64 +127,38 @@ function combineComponents<I, T extends ElementType>(
 }
 
 /**
- * An observable operator taking an array of items and mapping them directly to a component diff. Items ids are not
- * checked and a new component will be created for each new item.
- * @param creationFunction A function taking an item of type I and returning a new component.
- */
-function simpleComponentDiffer<I, T extends ElementType>(
-  creationFunction: (item: I) => Component<T>,
-): OperatorFunction<I[], ComponentDiff<I, T>> {
-  return (items$: Observable<I[]>) => {
-    // Hold previous item map for future reference.
-    let previousComponentMap = new Map<I, Component<T>>();
-    return items$.pipe(
-      map(items => {
-        // Map items to an array of components, new components will be created for any items not in the item map.
-        const componentArray = items.map(item => [item, previousComponentMap.get(item) || creationFunction(item)] as const);
-        const componentMap = new Map(componentArray);
-        const newComponents = items // Create an array components which were not in the previous item map.
-          .filter(item => !previousComponentMap.has(item))
-          .map(item => [item, componentMap.get(item)!] as [I, Component<T>]);
-        // Create an array of ids which are no longer present in the new component map.
-        const removedIds = Array.from(previousComponentMap.keys()).filter(item => !componentMap.has(item));
-        previousComponentMap = componentMap; // Save the current component map for the next emission.
-        return { newComponents, removedIds, ids: items };
-      }),
-    );
-  };
-}
-
-/**
  * An observable operator to map an array of items of type I to an array of component elements.
  * Items with matching ids between emissions will be passed to existing components rather than
  * regenerating them to more efficiently render.
- * @param idFunction A function taking an item of type I and returning it's unique id.
- * (If the creation function is passed here instead then item values will be used as their ids directly and the creation
- * function will take a non-observable item.)
  * @param creationFunction A function taking an item observable (and current item index observable if needed)
+ * @param idFunction Either: a function taking an item of type I and returning it's unique id,
+ * A prop name of I in which it's unique id can be found, or if omitted then the item index will be used as the id.
  * and returning a new component for the item.
  */
 export function mapToComponents<I, T extends ElementType>(
-  idFunction: (item: I, index: number) => Id,
   creationFunction: (item: Observable<I>, index: Observable<number>) => Component<T>,
 ): OperatorFunction<I[], ElementType[]>;
 export function mapToComponents<I, T extends ElementType>(
-  staticCreationFunction: (item: I) => Component<T>,
+  creationFunction: (item: Observable<I>, index: Observable<number>) => Component<T>,
+  idFunction: (item: I) => Id,
 ): OperatorFunction<I[], ElementType[]>;
 export function mapToComponents<I, T extends ElementType>(
-  idOrCreationFunction: ((item: I, index: number) => Id) | ((item: I) => Component<T>),
-  creationFunction?: (item: Observable<I>, index: Observable<number>) => Component<T>,
+  creationFunction: (item: Observable<I>, index: Observable<number>) => Component<T>,
+  keyProp: KeysOfValue<I, Id>,
+): OperatorFunction<I[], ElementType[]>;
+export function mapToComponents<I, T extends ElementType>(
+  creationFunction: (item: Observable<I>, index: Observable<number>) => Component<T>,
+  idPropOrFunction?: ((item: I, index: number) => Id) | KeysOfValue<I, Id>,
 ): OperatorFunction<I[], ElementType[]> {
-  if (creationFunction) {
-    return (items: Observable<I[]>) => items.pipe(
-      itemDiffer(idOrCreationFunction as (item: I, index: number) => Id),
-      createComponents(creationFunction),
-      combineComponents(),
-      startWith([]),
-    );
-  }
+  const idFunction: (item: I, index: number) => Id = idPropOrFunction ?
+    typeof idPropOrFunction === 'function' ?
+      idPropOrFunction as (item: I, index: number) => Id :
+      (item) => item[idPropOrFunction] as unknown as Id :
+    (_, i) => i;
+
   return (items: Observable<I[]>) => items.pipe(
-    simpleComponentDiffer(idOrCreationFunction as (item: I) => Component<T>),
+    itemDiffer(idFunction),
+    createComponents(creationFunction),
     combineComponents(),
     startWith([]),
   );

--- a/src/lib/rxfm/utils/types.ts
+++ b/src/lib/rxfm/utils/types.ts
@@ -7,3 +7,10 @@ export type StringLike = string | number;
 export type TypeOrObservable<T> = T | Observable<T>;
 
 export type PartialRecord<K extends string | number | symbol, T> = Partial<Record<K, T>>;
+
+/**
+ * A type to extract all keys from type T which have a corresponding value matching type V.
+ */
+export type KeysOfValue<T, V> = {
+  [K in keyof T]: T[K] extends V ? K : never
+}[keyof T];

--- a/src/lib/rxfm/utils/utils.ts
+++ b/src/lib/rxfm/utils/utils.ts
@@ -174,7 +174,7 @@ export function reuse<T>(source: Observable<T>): Observable<T> {
 /**
  * @returns An observable emitting the logical NOT value of the source observable's emissions.
  */
- export function notGate(source: Observable<any>): Observable<boolean> {
+ export function not(source: Observable<any>): Observable<boolean> {
   return source.pipe(
     distinctUntilChanged(),
     map(val => !val),
@@ -185,7 +185,7 @@ export function reuse<T>(source: Observable<T>): Observable<T> {
 /**
  * Take a spread array of observables and emit the logical AND value of all of their emissions whenever it changes.
  */
-export function andGate(...sources: Observable<any>[]): Observable<boolean> {
+export function and(...sources: Observable<any>[]): Observable<boolean> {
   return combineLatest(
     sources.map(source => source.pipe(distinctUntilChanged())),
   ).pipe(
@@ -197,14 +197,14 @@ export function andGate(...sources: Observable<any>[]): Observable<boolean> {
 /**
  * Take a spread array of observables and emit the logical NAND value of all of their emissions whenever it changes.
  */
-export function nandGate(...sources: Observable<any>[]): Observable<boolean> {
-  return notGate(andGate(...sources));
+export function nand(...sources: Observable<any>[]): Observable<boolean> {
+  return not(and(...sources));
 }
 
 /**
  * Take a spread array of observables and emit the logical OR value of all of their emissions whenever it changes.
  */
-export function orGate(...sources: Observable<any>[]): Observable<boolean> {
+export function or(...sources: Observable<any>[]): Observable<boolean> {
   return combineLatest(
     sources.map(source => source.pipe(distinctUntilChanged())),
   ).pipe(
@@ -216,8 +216,8 @@ export function orGate(...sources: Observable<any>[]): Observable<boolean> {
 /**
  * Take a spread array of observables and emit the logical NOR value of all of their emissions whenever it changes.
  */
-export function norGate(...sources: Observable<any>[]): Observable<boolean> {
-  return notGate(orGate(...sources));
+export function nor(...sources: Observable<any>[]): Observable<boolean> {
+  return not(or(...sources));
 }
 
 /**


### PR DESCRIPTION
- Reordered map to components arguments to take creation function first.
- Removed static creation function overload.
- Made index id default if no id function provided.
- Added ability to pass a key of I to calculate the id.
