### PR TITLE
v3.0.0-alpha.1: Fluent component API (Div.onClick(h)`text`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operator and chainable with the event methods.
 - Fluent `style` method (`` Div.style({ color: 'red' })`text` `` → `styles(...)`) and per-attribute
   methods (`` Input.type('text').placeholder('…')() `` → the `attribute` operator) on element
-  creators, chainable with the event and class methods.
+  creators, chainable with the event and class methods. A generic `attr(name, value)` method covers
+  attributes not in the typed map (`data-*`, `aria-*`, and other custom attributes).
 
 ## [3.0.0-alpha.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-alpha.1] - 2026-06-05
+
 ### Added
 - Fluent event methods on element creators: `` Div.onClick(handler)`text` `` is sugar for
   `` Div`text`.pipe(event.click(handler)) ``. Every event in `ElementEventMap` has a corresponding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fluent `class` method on element creators: `` Div.class('btn', isActive)`text` `` is sugar for
   `` Div`text`.pipe(classes('btn', isActive)) ``, taking the same arguments as the `classes`
   operator and chainable with the event methods.
+- Fluent `style` method (`` Div.style({ color: 'red' })`text` `` → `styles(...)`) and per-attribute
+  methods (`` Input.type('text').placeholder('…')() `` → the `attribute` operator) on element
+  creators, chainable with the event and class methods.
 
 ## [3.0.0-alpha.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `on<EventName>` method (`onClick`, `onInput`, …), plus a generic `on(type, handler)` form, and
   the methods may be chained (`Button.onClick(a).onMouseenter(b)`). The new `chainable` helper and
   `ChainableComponentCreator` type are exported for use with custom component creators.
+- Fluent `class` method on element creators: `` Div.class('btn', isActive)`text` `` is sugar for
+  `` Div`text`.pipe(classes('btn', isActive)) ``, taking the same arguments as the `classes`
+  operator and chainable with the event methods.
 
 ## [3.0.0-alpha.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Fluent event methods on element creators: `` Div.onClick(handler)`text` `` is sugar for
+  `` Div`text`.pipe(event.click(handler)) ``. Every event in `ElementEventMap` has a corresponding
+  `on<EventName>` method (`onClick`, `onInput`, …), plus a generic `on(type, handler)` form, and
+  the methods may be chained (`Button.onClick(a).onMouseenter(b)`). The new `chainable` helper and
+  `ChainableComponentCreator` type are exported for use with custom component creators.
+
 ## [3.0.0-alpha.0] - 2026-06-04
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -94,30 +94,30 @@ const TaggedTemplateExample = Div`We can use ${B`tagged templates!`}`;
 ---
 
 ## State & Events
-State can be held in `BehaviorSubjects` and used in a similar way to the `useState` hook in React. The `event` operator function lets us handle element events.
+State can be held in `BehaviorSubjects` and used in a similar way to the `useState` hook in React. Element creators expose fluent methods for handling events — for every DOM event there's a matching `on<Event>` method (`onClick`, `onInput`, …):
 
 ```typescript
-import { Button, event } from 'rxfm';
+import { Button } from 'rxfm';
 import { BehaviorSubject } from 'rxjs';
 
 const ClickCounter = () => {
   const clicks = new BehaviorSubject(0);
 
-  return Button`Clicks: ${clicks}`.pipe(
-    event('click', () => clicks.next(clicks.value + 1)),
-  );
+  return Button.onClick(() => clicks.next(clicks.value + 1))`Clicks: ${clicks}`;
 };
 ```
 
-Here the `event` operator is what I've called a "component operator". These are operator functions taking a component observable, processing its element in some way, and returning the same component observable. In this case the component operator adds an event listener to the element.
-
-The `event` operator also allows each event type to be accessed as a property:
+These fluent methods are sugar for "component operators" applied via `.pipe`. A component operator is an operator function taking a component observable, processing its element in some way (here, adding an event listener), and returning the same component observable. The example above is equivalent to using the `event` operator directly:
 
 ```typescript
+import { Button, event } from 'rxfm';
+
 Button`Clicks: ${clicks}`.pipe(
   event.click(() => clicks.next(clicks.value + 1)),
 );
 ```
+
+The fluent methods can be chained, so several may be combined (`Button.onClick(handleClick).onMouseenter(handleHover)`), and a generic `on(type, handler)` form is available for dynamic event types.
 
 When components store state like this, they should be declared as functions as above so that instances of the component don't interfere with each-other.
 
@@ -128,39 +128,34 @@ Using Subjects to store state gives us an advantage over React in that we don't 
 ---
 
 ## Attributes & Styling
-Element attributes and styling can be set using operator functions imported from `rxfm`:
+Element styles, CSS classes, and attributes can be set using fluent methods on element creators:
 
 ```typescript
-import { styles, classes, attributes, Div, Input } from 'rxfm';
+import { Div, Input } from 'rxfm';
 ```
 
 ```typescript
-const StylesExample = Div`We can add styles`.pipe(
-  styles({
-    color: 'blue',
-    fontStyle: 'italic',
-  }),
-);
+const StylesExample = Div.style({
+  color: 'blue',
+  fontStyle: 'italic',
+})`We can add styles`;
 ```
 
 ```typescript
-const ClassExample = Div`We can add CSS classes`.pipe(
-  classes('example-class'),
-);
+const ClassExample = Div.class('example-class')`We can add CSS classes`;
 ```
+
+Each known attribute has its own method, and they chain like the event methods:
 
 ```typescript
-const AttributesExample = Input().pipe(
-  attributes({
-    type: 'text',
-    placeholder: 'We can set element attributes',
-  }),
-);
+const AttributesExample = Input
+  .type('text')
+  .placeholder('We can set element attributes')();
 ```
 
-Style, attributes and CSS class values may be strings, or they can be observables to set them dynamically.
+Style, attribute and CSS class values may be strings, or they can be observables to set them dynamically. A generic `attr(name, value)` method covers attributes outside the typed set (`data-*`, `aria-*`, and other custom attributes).
 
-We can also access individual operators for styles and attributes, as well as using the tagged template syntax:
+Like the event methods, `style`, `class`, and the attribute methods are sugar for the `styles`, `classes`, and `attribute` component operators, which can also be applied directly via `.pipe`. The operator forms additionally support a tagged template syntax and let us access individual style and attribute properties:
 
 ```typescript
 const StyleExample = Div`We access styles as properties and use tagged templates`.pipe(
@@ -234,10 +229,10 @@ interface OptionButtonProps {
   active: Observable<boolean>;
 }
 
-const OptionButton = ({ option, setOption, active }: OptionButtonProps) => Button(option).pipe(
-  event.click(() => setOption(option)),
-  classes`option-button ${conditional(active, 'active')}`,
-);
+const OptionButton = ({ option, setOption, active }: OptionButtonProps) =>
+  Button
+    .onClick(() => setOption(option))
+    .class('option-button', conditional(active, 'active'))(option);
 
 const options = ['Option 1', 'Option 2', 'Option 3'];
 
@@ -260,9 +255,7 @@ const ComponentIOExample = () => {
 Component children can be passed in using the `ComponentChild` type. A variable number of component children can be passed in using a spread array:
 
 ```typescript
-const Card = (...children: ComponentChild[]) => Div(...children).pipe(
-  classes`card`,
-);
+const Card = (...children: ComponentChild[]) => Div.class('card')(...children);
 ```
 
 [Code](https://github.com/alden12/rxfm/blob/master/src/app/basic-examples/component-io.ts) | [Live Demo](https://alden12.github.io/rxfm/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxfm",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "author": "Alden Laslett",
   "description": "A Web Framework Built on RxJS",
   "license": "MIT",

--- a/src/app/basic-examples/attributes-and-styling.ts
+++ b/src/app/basic-examples/attributes-and-styling.ts
@@ -1,15 +1,14 @@
-import { Div, styles, classes, Input, attributes, style, attribute } from 'rxfm';
+import { Div, classes, Input, attributes, style, attribute } from 'rxfm';
 import { timer } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import './example-styles.css';
 
-export const StylesExample = Div`We can add styles`.pipe(
-  styles({
-    color: 'blue',
-    fontStyle: 'italic',
-  })
-);
+// The fluent `style` method is sugar for the `styles` operator.
+export const StylesExample = Div.style({
+  color: 'blue',
+  fontStyle: 'italic',
+})`We can add styles`;
 
 export const DynamicStyles = Div`Styles can be dynamic`.pipe(
   style('color', timer(0, 1000).pipe(map(i => i % 2 ? 'red' : 'blue'))),
@@ -31,12 +30,10 @@ export const DynamicClasses = Div.class(
   timer(0, 1000).pipe(map(i => i % 2 ? 'another-class' : null)),
 )`Classes can be dynamic`;
 
-export const AttributesExample = Input().pipe(
-  attributes({
-    type: 'text',
-    placeholder: 'We can set element attributes'
-  }),
-);
+// Per-attribute fluent methods are sugar for the `attribute` operator.
+export const AttributesExample = Input
+  .type('text')
+  .placeholder('We can set element attributes')();
 
 export const DynamicAttributes = Input().pipe(
   attributes({

--- a/src/app/basic-examples/attributes-and-styling.ts
+++ b/src/app/basic-examples/attributes-and-styling.ts
@@ -19,20 +19,17 @@ export const StyleExample = Div`We access styles as properties and use tagged te
   style.color`blue`,
 );
 
-export const ClassExample = Div`We can add CSS classes`.pipe(
-  classes('example-class'),
-);
+// The fluent `class` method is sugar for the `classes` operator.
+export const ClassExample = Div.class('example-class')`We can add CSS classes`;
 
 export const TaggedTemplateClassExample = Div`We can use the tagged template syntax for classes`.pipe(
   classes`example-class`,
 );
 
-export const DynamicClasses = Div`Classes can be dynamic`.pipe(
-  classes(
-    'example-class',
-    timer(0, 1000).pipe(map(i => i % 2 ? 'another-class' : null)),
-  ),
-);
+export const DynamicClasses = Div.class(
+  'example-class',
+  timer(0, 1000).pipe(map(i => i % 2 ? 'another-class' : null)),
+)`Classes can be dynamic`;
 
 export const AttributesExample = Input().pipe(
   attributes({

--- a/src/app/basic-examples/state-and-events.ts
+++ b/src/app/basic-examples/state-and-events.ts
@@ -1,11 +1,12 @@
-import { Button, event } from 'rxfm';
-import { BehaviorSubject } from 'rxjs';
+import { Button } from "rxfm";
+import { BehaviorSubject } from "rxjs";
 
 export const ClickCounter = () => {
   const clicks = new BehaviorSubject(0);
 
-  return Button`Clicks: ${clicks}`.pipe(
-    event.click(() => clicks.next(clicks.value + 1)),
-    // May also be written as: `event('click', () => clicks.next(clicks.value + 1))`,
-  );
+  // Fluent event methods (`onClick`, `onInput`, …) are sugar for the equivalent `event` operator.
+  return Button.onClick(() => clicks.next(clicks.value + 1))`Clicks: ${clicks}`;
+  // Equivalent to:
+  //   Button`Clicks: ${clicks}`.pipe(event.click(() => clicks.next(clicks.value + 1)))
+  // The generic form `Button.on('click', handler)` is also available.
 };

--- a/src/lib/rxfm/components/chainable-creator.test.ts
+++ b/src/lib/rxfm/components/chainable-creator.test.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject, Observable } from "rxjs";
 import { Component, ElementType } from ".";
-import { Div, Button } from "./html";
+import { Div, Button, Input } from "./html";
 
 const testComponent = <T extends ElementType>(component: Component<T>) => {
   let element: T | undefined = undefined;
@@ -94,6 +94,47 @@ describe('chainable creator', () => {
       .class('btn')`x`;
     const { element, unsubscribe } = testComponent(component);
     expect(element.classList.contains('btn')).toBe(true);
+    element.dispatchEvent(new MouseEvent('click'));
+    expect(clicked).toBe(true);
+    unsubscribe();
+  });
+
+  it('should apply styles via the style method', () => {
+    const component = Div.style({ color: 'blue', fontStyle: 'italic' })`x`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element.style.color).toEqual('blue');
+    expect(element.style.fontStyle).toEqual('italic');
+    unsubscribe();
+  });
+
+  it('should set an attribute via a per-attribute method', () => {
+    const component = Input.type('text')`x`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element.getAttribute('type')).toEqual('text');
+    unsubscribe();
+  });
+
+  it('should reflect a dynamic attribute from an observable', () => {
+    const placeholder = new BehaviorSubject('first');
+    const component = Input.placeholder(placeholder)`x`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element.getAttribute('placeholder')).toEqual('first');
+    placeholder.next('second');
+    expect(element.getAttribute('placeholder')).toEqual('second');
+    unsubscribe();
+  });
+
+  it('should chain attribute, style, class and event methods together', () => {
+    let clicked = false;
+    const component = Input
+      .type('text')
+      .class('field')
+      .style({ color: 'red' })
+      .onClick(() => { clicked = true; })`x`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element.getAttribute('type')).toEqual('text');
+    expect(element.classList.contains('field')).toBe(true);
+    expect(element.style.color).toEqual('red');
     element.dispatchEvent(new MouseEvent('click'));
     expect(clicked).toBe(true);
     unsubscribe();

--- a/src/lib/rxfm/components/chainable-creator.test.ts
+++ b/src/lib/rxfm/components/chainable-creator.test.ts
@@ -1,0 +1,77 @@
+import { Observable } from "rxjs";
+import { Component, ElementType } from ".";
+import { Div, Button } from "./html";
+
+const testComponent = <T extends ElementType>(component: Component<T>) => {
+  let element: T | undefined = undefined;
+  const subscription = component.subscribe(el => { element = el });
+  return { element: element!, unsubscribe: () => subscription.unsubscribe() };
+};
+
+describe('chainable creator', () => {
+  it('should return an observable when a fluent event method is used with children', () => {
+    const component = Div.onClick(() => {})`hello`;
+    expect(component).toBeInstanceOf(Observable);
+  });
+
+  it('should keep the tagged template children when a fluent event method is used', () => {
+    const component = Div.onClick(() => {})`+1`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element).toBeInstanceOf(HTMLDivElement);
+    expect(element.firstChild?.textContent).toEqual('+1');
+    unsubscribe();
+  });
+
+  it('should invoke the handler with the event when the event fires', () => {
+    let received: Event | undefined;
+    const component = Button.onClick(ev => { received = ev; })`click me`;
+    const { element, unsubscribe } = testComponent(component);
+    const clickEvent = new MouseEvent('click');
+    element.dispatchEvent(clickEvent);
+    expect(received).toBe(clickEvent);
+    unsubscribe();
+  });
+
+  it('should support the generic on(type, handler) form', () => {
+    let received: Event | undefined;
+    const component = Div.on('click', ev => { received = ev; })`x`;
+    const { element, unsubscribe } = testComponent(component);
+    const clickEvent = new MouseEvent('click');
+    element.dispatchEvent(clickEvent);
+    expect(received).toBe(clickEvent);
+    unsubscribe();
+  });
+
+  it('should register every handler when event methods are chained', () => {
+    let clicked = false;
+    let entered = false;
+    const component = Div
+      .onClick(() => { clicked = true; })
+      .onMouseenter(() => { entered = true; })`x`;
+    const { element, unsubscribe } = testComponent(component);
+    element.dispatchEvent(new MouseEvent('click'));
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    expect(clicked).toBe(true);
+    expect(entered).toBe(true);
+    unsubscribe();
+  });
+
+  it('should produce a childless element when terminated with an empty call', () => {
+    let clicked = false;
+    const component = Div.onClick(() => { clicked = true; })();
+    const { element, unsubscribe } = testComponent(component);
+    expect(element).toBeInstanceOf(HTMLDivElement);
+    expect(element.childNodes.length).toEqual(0);
+    element.dispatchEvent(new MouseEvent('click'));
+    expect(clicked).toBe(true);
+    unsubscribe();
+  });
+
+  it('should not affect the plain creator forms', () => {
+    const component = Div('plain');
+    const { element, unsubscribe } = testComponent(component);
+    expect(element).toBeInstanceOf(HTMLDivElement);
+    expect(element.firstChild?.textContent).toEqual('plain');
+    unsubscribe();
+  });
+});

--- a/src/lib/rxfm/components/chainable-creator.test.ts
+++ b/src/lib/rxfm/components/chainable-creator.test.ts
@@ -4,7 +4,7 @@ import { Div, Button, Input } from "./html";
 
 const testComponent = <T extends ElementType>(component: Component<T>) => {
   let element: T | undefined = undefined;
-  const subscription = component.subscribe(el => { element = el });
+  const subscription = component.subscribe(el => { element = el; });
   return { element: element!, unsubscribe: () => subscription.unsubscribe() };
 };
 

--- a/src/lib/rxfm/components/chainable-creator.test.ts
+++ b/src/lib/rxfm/components/chainable-creator.test.ts
@@ -124,6 +124,17 @@ describe('chainable creator', () => {
     unsubscribe();
   });
 
+  it('should set a custom attribute via the generic attr method', () => {
+    const value = new BehaviorSubject('42');
+    const component = Div.attr('data-id', value).attr('aria-label', 'Row')`x`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element.getAttribute('data-id')).toEqual('42');
+    expect(element.getAttribute('aria-label')).toEqual('Row');
+    value.next('43');
+    expect(element.getAttribute('data-id')).toEqual('43');
+    unsubscribe();
+  });
+
   it('should chain attribute, style, class and event methods together', () => {
     let clicked = false;
     const component = Input

--- a/src/lib/rxfm/components/chainable-creator.test.ts
+++ b/src/lib/rxfm/components/chainable-creator.test.ts
@@ -1,4 +1,4 @@
-import { Observable } from "rxjs";
+import { BehaviorSubject, Observable } from "rxjs";
 import { Component, ElementType } from ".";
 import { Div, Button } from "./html";
 
@@ -62,6 +62,38 @@ describe('chainable creator', () => {
     const { element, unsubscribe } = testComponent(component);
     expect(element).toBeInstanceOf(HTMLDivElement);
     expect(element.childNodes.length).toEqual(0);
+    element.dispatchEvent(new MouseEvent('click'));
+    expect(clicked).toBe(true);
+    unsubscribe();
+  });
+
+  it('should apply CSS classes via the class method', () => {
+    const component = Div.class('one', 'two')`x`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element.classList.contains('one')).toBe(true);
+    expect(element.classList.contains('two')).toBe(true);
+    unsubscribe();
+  });
+
+  it('should reflect a dynamic class from an observable', () => {
+    const active = new BehaviorSubject<string | null>('active');
+    const component = Div.class('base', active)`x`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element.classList.contains('base')).toBe(true);
+    expect(element.classList.contains('active')).toBe(true);
+    active.next(null);
+    expect(element.classList.contains('active')).toBe(false);
+    expect(element.classList.contains('base')).toBe(true);
+    unsubscribe();
+  });
+
+  it('should chain class with event methods', () => {
+    let clicked = false;
+    const component = Div
+      .onClick(() => { clicked = true; })
+      .class('btn')`x`;
+    const { element, unsubscribe } = testComponent(component);
+    expect(element.classList.contains('btn')).toBe(true);
     element.dispatchEvent(new MouseEvent('click'));
     expect(clicked).toBe(true);
     unsubscribe();

--- a/src/lib/rxfm/components/chainable-creator.ts
+++ b/src/lib/rxfm/components/chainable-creator.ts
@@ -39,12 +39,16 @@ export type StyleChainMethods<T extends ElementType> = {
 };
 
 /**
- * Fluent attribute methods added to an element creator. For each attribute name there is a
+ * Fluent attribute methods added to an element creator. For each known attribute name there is a
  * corresponding method (eg. `Input.type('text')`, `Div.id('app')`) which is sugar for the
- * equivalent `attribute` operator and returns a new chainable creator so calls may be chained.
+ * equivalent `attribute` operator and returns a new chainable creator so calls may be chained. The
+ * generic `attr(name, value)` method covers attributes not in the typed map (`data-*`, `aria-*`,
+ * and other custom attributes).
  */
 export type AttributeChainMethods<T extends ElementType> = {
   [K in AttributeKeys]: (value: TypeOrObservable<AttributeType>) => ChainableComponentCreator<T>;
+} & {
+  attr(name: string, value?: TypeOrObservable<AttributeType>): ChainableComponentCreator<T>;
 };
 
 /**
@@ -104,6 +108,10 @@ export function chainable<T extends ElementType>(
         if (/^on[A-Z]/.test(prop)) {
           const type = (prop[2].toLowerCase() + prop.slice(3)) as keyof ElementEventMap;
           return (handler: EventHandler<T, keyof ElementEventMap>) => next(event(type, handler));
+        }
+        if (prop === 'attr') {
+          return (name: string, value?: TypeOrObservable<AttributeType>) =>
+            next(attribute(name, value));
         }
         // Any other name is an individual attribute: `Input.type('text')` → `attribute('type', …)`.
         return (value: TypeOrObservable<AttributeType>) => next(attribute(prop, value));

--- a/src/lib/rxfm/components/chainable-creator.ts
+++ b/src/lib/rxfm/components/chainable-creator.ts
@@ -1,5 +1,9 @@
+import { Observable } from "rxjs";
 import { event, ElementEventMap, EventHandler } from "../events";
-import { classes, ClassType } from "../attributes";
+import {
+  classes, ClassType, attribute, AttributeKeys, AttributeType, styles, Styles, StyleObject,
+} from "../attributes";
+import { TypeOrObservable } from "../utils";
 import { Component, ComponentCreator, ComponentOperator, ElementType } from "./component";
 
 /**
@@ -27,21 +31,43 @@ export type ClassChainMethods<T extends ElementType> = {
 };
 
 /**
- * An element creator which, in addition to the standard call and tagged template syntax for
- * providing children, exposes fluent methods which apply the equivalent component operator via
- * `.pipe`. Event methods (`Div.onClick(handler)`) are sugar for the `event` operator, eg:
- * `` Div.onClick(handler)`text` `` is equivalent to `` Div`text`.pipe(event.click(handler)) ``; the
- * `class` method is sugar for the `classes` operator. Methods may be chained.
+ * Fluent styles method added to an element creator. `style` is sugar for the `styles` operator,
+ * taking a styles dictionary (or observable emitting one) and returning a new chainable creator.
  */
-export type ChainableComponentCreator<T extends ElementType = ElementType> =
-  ComponentCreator<T> & EventChainMethods<T> & ClassChainMethods<T>;
+export type StyleChainMethods<T extends ElementType> = {
+  style(styleDict: Styles | Observable<StyleObject>): ChainableComponentCreator<T>;
+};
 
 /**
- * Wrap a component creator so that it gains fluent event methods (`onClick`, `onInput`, …, and the
- * generic `on(type, handler)`) in addition to its existing call and tagged template syntax.
- * Each event method appends the equivalent `event` operator and returns a new chainable creator, so
- * the calls may be chained. The accumulated operators are applied (via `.pipe`) once children are
- * provided by the terminal call or tagged template.
+ * Fluent attribute methods added to an element creator. For each attribute name there is a
+ * corresponding method (eg. `Input.type('text')`, `Div.id('app')`) which is sugar for the
+ * equivalent `attribute` operator and returns a new chainable creator so calls may be chained.
+ */
+export type AttributeChainMethods<T extends ElementType> = {
+  [K in AttributeKeys]: (value: TypeOrObservable<AttributeType>) => ChainableComponentCreator<T>;
+};
+
+/**
+ * An element creator which, in addition to the standard call and tagged template syntax for
+ * providing children, exposes fluent methods which apply the equivalent component operator via
+ * `.pipe`. Sugar is provided for events (`Div.onClick(handler)` → the `event` operator), CSS classes
+ * (`Div.class('x')` → `classes`), styles (`Div.style({ color: 'red' })` → `styles`), and individual
+ * attributes (`Input.type('text')` → the `attribute` operator). All methods return a chainable
+ * creator, so they may be chained, eg: `` Input.type('text').onInput(handler).class('field')`` ``.
+ */
+export type ChainableComponentCreator<T extends ElementType = ElementType> =
+  ComponentCreator<T>
+  & EventChainMethods<T>
+  & ClassChainMethods<T>
+  & StyleChainMethods<T>
+  & AttributeChainMethods<T>;
+
+/**
+ * Wrap a component creator so that it gains fluent operator methods (events such as `onClick`, plus
+ * `class`, `style`, and per-attribute methods like `id` or `type`) in addition to its existing call
+ * and tagged template syntax. Each method appends the equivalent component operator and returns a
+ * new chainable creator, so calls may be chained. The accumulated operators are applied (via
+ * `.pipe`) once children are provided by the terminal call or tagged template.
  * @param create The base component creator to make chainable.
  * @param ops The operators accumulated so far in the chain (used internally; defaults to none).
  * @returns A chainable component creator of type T.
@@ -58,22 +84,29 @@ export function chainable<T extends ElementType>(
     return ops.reduce((result, op) => result.pipe(op), component);
   };
 
+  const next = (op: ComponentOperator<T>) => chainable<T>(create, [...ops, op]);
+
   return new Proxy(build, {
     get(target, prop, receiver) {
-      if (typeof prop === 'string') {
+      // Only string keys which aren't already function members (name, length, bind, …) are treated
+      // as fluent methods. `then` is excluded so the builder is never mistaken for a thenable.
+      if (typeof prop === 'string' && prop !== 'then' && !(prop in target)) {
         if (prop === 'class') {
-          return (...classNames: ClassType[]) =>
-            chainable<T>(create, [...ops, classes<T>(...classNames)]);
+          return (...classNames: ClassType[]) => next(classes<T>(...classNames));
+        }
+        if (prop === 'style') {
+          return (styleDict: Styles | Observable<StyleObject>) => next(styles<T>(styleDict));
         }
         if (prop === 'on') {
           return (type: keyof ElementEventMap, handler: EventHandler<T, keyof ElementEventMap>) =>
-            chainable<T>(create, [...ops, event(type, handler)]);
+            next(event(type, handler));
         }
         if (/^on[A-Z]/.test(prop)) {
           const type = (prop[2].toLowerCase() + prop.slice(3)) as keyof ElementEventMap;
-          return (handler: EventHandler<T, keyof ElementEventMap>) =>
-            chainable<T>(create, [...ops, event(type, handler)]);
+          return (handler: EventHandler<T, keyof ElementEventMap>) => next(event(type, handler));
         }
+        // Any other name is an individual attribute: `Input.type('text')` → `attribute('type', …)`.
+        return (value: TypeOrObservable<AttributeType>) => next(attribute(prop, value));
       }
       return Reflect.get(target, prop, receiver);
     },

--- a/src/lib/rxfm/components/chainable-creator.ts
+++ b/src/lib/rxfm/components/chainable-creator.ts
@@ -1,0 +1,65 @@
+import { event, ElementEventMap, EventHandler } from "../events";
+import { Component, ComponentCreator, ComponentOperator, ElementType } from "./component";
+
+/**
+ * Fluent event methods added to an element creator. For each event name in the `ElementEventMap`
+ * there is a corresponding `on<EventName>` method (eg. `onClick`, `onInput`), as well as a generic
+ * `on` method taking the event type explicitly. Each returns a new chainable creator carrying the
+ * added event operator, so calls may be chained: `Button.onClick(a).onMouseenter(b)`.
+ */
+export type EventChainMethods<T extends ElementType> = {
+  // Reversible because all DOM event names are lowercase: `Capitalize<'click'>` is `'Click'`.
+  [E in keyof ElementEventMap as `on${Capitalize<E>}`]:
+    (handler: EventHandler<T, E>) => ChainableComponentCreator<T>;
+} & {
+  on<E extends keyof ElementEventMap>(type: E, handler: EventHandler<T, E>): ChainableComponentCreator<T>;
+};
+
+/**
+ * An element creator which, in addition to the standard call and tagged template syntax for
+ * providing children, exposes fluent event methods (`Div.onClick(handler)`). These are sugar for
+ * applying the equivalent `event` operator via `.pipe`, eg: `` Div.onClick(handler)`text` `` is
+ * equivalent to `` Div`text`.pipe(event.click(handler)) ``.
+ */
+export type ChainableComponentCreator<T extends ElementType = ElementType> =
+  ComponentCreator<T> & EventChainMethods<T>;
+
+/**
+ * Wrap a component creator so that it gains fluent event methods (`onClick`, `onInput`, …, and the
+ * generic `on(type, handler)`) in addition to its existing call and tagged template syntax.
+ * Each event method appends the equivalent `event` operator and returns a new chainable creator, so
+ * the calls may be chained. The accumulated operators are applied (via `.pipe`) once children are
+ * provided by the terminal call or tagged template.
+ * @param create The base component creator to make chainable.
+ * @param ops The operators accumulated so far in the chain (used internally; defaults to none).
+ * @returns A chainable component creator of type T.
+ */
+export function chainable<T extends ElementType>(
+  create: ComponentCreator<T>,
+  ops: ComponentOperator<T>[] = [],
+): ChainableComponentCreator<T> {
+  // `build` is callable and taggable: it forwards all arguments to the base creator unchanged
+  // (which already routes between the TemplateStringsArray and children forms) then applies any
+  // accumulated operators.
+  const build = (...args: unknown[]) => {
+    const component = (create as (...a: unknown[]) => Component<T>)(...args);
+    return ops.reduce((result, op) => result.pipe(op), component);
+  };
+
+  return new Proxy(build, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'string') {
+        if (prop === 'on') {
+          return (type: keyof ElementEventMap, handler: EventHandler<T, keyof ElementEventMap>) =>
+            chainable<T>(create, [...ops, event(type, handler)]);
+        }
+        if (/^on[A-Z]/.test(prop)) {
+          const type = (prop[2].toLowerCase() + prop.slice(3)) as keyof ElementEventMap;
+          return (handler: EventHandler<T, keyof ElementEventMap>) =>
+            chainable<T>(create, [...ops, event(type, handler)]);
+        }
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as unknown as ChainableComponentCreator<T>;
+}

--- a/src/lib/rxfm/components/chainable-creator.ts
+++ b/src/lib/rxfm/components/chainable-creator.ts
@@ -1,4 +1,5 @@
 import { event, ElementEventMap, EventHandler } from "../events";
+import { classes, ClassType } from "../attributes";
 import { Component, ComponentCreator, ComponentOperator, ElementType } from "./component";
 
 /**
@@ -16,13 +17,24 @@ export type EventChainMethods<T extends ElementType> = {
 };
 
 /**
+ * Fluent CSS class method added to an element creator. `class` is sugar for the `classes` operator,
+ * taking the same spread of class names (strings, observables, or observable string arrays; falsy
+ * values remove the class) and returning a new chainable creator so it may be chained with other
+ * methods.
+ */
+export type ClassChainMethods<T extends ElementType> = {
+  class(...classNames: ClassType[]): ChainableComponentCreator<T>;
+};
+
+/**
  * An element creator which, in addition to the standard call and tagged template syntax for
- * providing children, exposes fluent event methods (`Div.onClick(handler)`). These are sugar for
- * applying the equivalent `event` operator via `.pipe`, eg: `` Div.onClick(handler)`text` `` is
- * equivalent to `` Div`text`.pipe(event.click(handler)) ``.
+ * providing children, exposes fluent methods which apply the equivalent component operator via
+ * `.pipe`. Event methods (`Div.onClick(handler)`) are sugar for the `event` operator, eg:
+ * `` Div.onClick(handler)`text` `` is equivalent to `` Div`text`.pipe(event.click(handler)) ``; the
+ * `class` method is sugar for the `classes` operator. Methods may be chained.
  */
 export type ChainableComponentCreator<T extends ElementType = ElementType> =
-  ComponentCreator<T> & EventChainMethods<T>;
+  ComponentCreator<T> & EventChainMethods<T> & ClassChainMethods<T>;
 
 /**
  * Wrap a component creator so that it gains fluent event methods (`onClick`, `onInput`, …, and the
@@ -49,6 +61,10 @@ export function chainable<T extends ElementType>(
   return new Proxy(build, {
     get(target, prop, receiver) {
       if (typeof prop === 'string') {
+        if (prop === 'class') {
+          return (...classNames: ClassType[]) =>
+            chainable<T>(create, [...ops, classes<T>(...classNames)]);
+        }
         if (prop === 'on') {
           return (type: keyof ElementEventMap, handler: EventHandler<T, keyof ElementEventMap>) =>
             chainable<T>(create, [...ops, event(type, handler)]);

--- a/src/lib/rxfm/components/html.ts
+++ b/src/lib/rxfm/components/html.ts
@@ -1,14 +1,17 @@
-import { componentCreator, ComponentCreator, componentFunction } from "./component";
+import { componentCreator, componentFunction } from "./component";
+import { chainable, ChainableComponentCreator } from "./chainable-creator";
 
 /**
- * A function to return a component creator for an HTML element with the given tag name.
+ * A function to return a component creator for an HTML element with the given tag name. The creator
+ * supports the standard call and tagged template syntax for children, plus fluent event methods
+ * such as `Div.onClick(handler)`.
  */
 export function htmlComponentCreator<K extends keyof HTMLElementTagNameMap>(
   tagName: K,
-): ComponentCreator<HTMLElementTagNameMap[K]> {
-  return componentCreator(
+): ChainableComponentCreator<HTMLElementTagNameMap[K]> {
+  return chainable(componentCreator(
     componentFunction(() => document.createElement(tagName)),
-  );
+  ));
 }
 
 export const A = htmlComponentCreator('a');

--- a/src/lib/rxfm/components/index.ts
+++ b/src/lib/rxfm/components/index.ts
@@ -1,4 +1,5 @@
 export * from './component';
+export * from './chainable-creator';
 export * from './html';
 export * from './svg';
 export * from './add-to-view';

--- a/src/lib/rxfm/components/svg.ts
+++ b/src/lib/rxfm/components/svg.ts
@@ -1,16 +1,19 @@
-import { componentCreator, ComponentCreator, componentFunction } from "./component";
+import { componentCreator, componentFunction } from "./component";
+import { chainable, ChainableComponentCreator } from "./chainable-creator";
 
 const SVGNamespace = 'http://www.w3.org/2000/svg';
 
 /**
- * A function to return a component creator for an SVG element with the given tag name.
+ * A function to return a component creator for an SVG element with the given tag name. The creator
+ * supports the standard call and tagged template syntax for children, plus fluent event methods
+ * such as `Circle.onClick(handler)`.
  */
 export function svgComponentCreator<K extends keyof SVGElementTagNameMap>(
   tagName: K,
-): ComponentCreator<SVGElementTagNameMap[K]> {
-  return componentCreator(
+): ChainableComponentCreator<SVGElementTagNameMap[K]> {
+  return chainable(componentCreator(
     componentFunction(() => document.createElementNS(SVGNamespace, tagName)),
-  );
+  ));
 }
 
 export const SvgA = svgComponentCreator('a');


### PR DESCRIPTION
Builds on the `3.0.0-alpha.0` base (#64, merged). Adds a fluent, React-prop-like authoring sugar where component operators read as chained members on the element creator. Pure sugar over `.pipe(...)` — implemented in rxfm core via a single `Proxy` builder (`chainable`), with the method surface generated by mapped types so editor autocomplete is fully typed.

## Added — `3.0.0-alpha.1`
- **Fluent event methods**: `` Div.onClick(handler)`text` `` ≡ `` Div`text`.pipe(event.click(handler)) ``. Every `ElementEventMap` event gets an `on<Event>` method, plus a generic `on(type, handler)`. Chainable: `Button.onClick(a).onMouseenter(b)`.
- **Fluent `class`**: `` Div.class('btn', isActive)`text` `` → `classes(...)` (same args as the operator).
- **Fluent `style`**: `` Div.style({ color: 'red' })`text` `` → `styles(...)`.
- **Per-attribute methods**: `` Input.type('text').placeholder('…')() `` → the `attribute` operator. Typed against the known attribute names.
- **Generic `attr(name, value)`**: escape hatch for attributes outside the typed map (`data-*`, `aria-*`, custom).
- Exports `chainable` + `ChainableComponentCreator` for custom creators.

All methods chain in any order and terminate with the existing call / tagged-template child syntax. Plain creator forms are unaffected.

## Tests
- New `chainable-creator.test.ts` (11 cases): Observable identity, tagged-template children preserved, handler invocation, generic `on`, chained events, childless terminal, classes (static + observable), styles, per-attribute (static + observable), generic `attr`, four-way chain, and plain-form regression. **21/21 suite passes**, `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)