### PR TITLE
Fix CI status badge URL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RxFM - A Web Framework Built on RxJS
 
-![Node.js CI](https://github.com/alden12/rxfm/workflows/Node.js%20CI/badge.svg?branch=master)
+[![Node.js CI](https://github.com/alden12/rxfm/actions/workflows/nodejs.yml/badge.svg?branch=master)](https://github.com/alden12/rxfm/actions/workflows/nodejs.yml)
 [![NPM](https://img.shields.io/npm/v/rxfm)](https://www.npmjs.com/package/rxfm)
 [![Bundlephobia](https://img.shields.io/bundlephobia/minzip/rxfm?label=gzipped)](https://bundlephobia.com/result?p=rxfm@latest)
 [![MIT license](https://img.shields.io/npm/l/rxfm)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
The README's CI badge used GitHub's **legacy** badge URL (`/<owner>/<repo>/workflows/<name>/badge.svg`), which now renders as **"no status"** rather than the build result.

Switched to the current format pointing at the workflow file, and wrapped it in a link to the Actions page (matching the other badges):

```
[![Node.js CI](https://github.com/alden12/rxfm/actions/workflows/nodejs.yml/badge.svg?branch=master)](https://github.com/alden12/rxfm/actions/workflows/nodejs.yml)
```

Verified the new URL's SVG reports `Node.js CI - passing` where the old one reported `Node.js CI - no status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)