### PR TITLE
RxFM improvements: unit-test sweep + correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Reordering keyed child elements (e.g. via `mapToComponents` when a list re-sorts or items move)
+  now patches the DOM correctly. The child-diff algorithm previously kept nodes in place that had
+  actually swapped relative order, leaving the DOM in the wrong order — and a falsy-zero bug meant a
+  node moving to the very front was treated as not having moved. Additions, removals, and
+  truncations were unaffected. The diff now keeps the longest already-in-order run of nodes in place
+  (its longest increasing subsequence) and moves only the rest, which is both correct and minimal in
+  DOM operations. Covered by a new exhaustive `childDiffer` test suite.
+
 ## [3.0.0-alpha.1] - 2026-06-05
 
 ### Added

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,4 +1,4 @@
-import { attribute, ComponentChild, Div, H1, H3, classes, Span, A } from 'rxfm';
+import { addToView, attribute, ComponentChild, Div, H1, H3, classes, Span, A } from 'rxfm';
 import {
   HelloWorld,
   ChildrenExample,
@@ -64,4 +64,4 @@ const App = Div(Title,  Examples).pipe(
   attribute.id`app`,
 );
 
-App.subscribe(element => document.body.appendChild(element));
+addToView(App);

--- a/src/lib/rxfm/attributes/attribute-operator-isolation.test.ts
+++ b/src/lib/rxfm/attributes/attribute-operator-isolation.test.ts
@@ -1,0 +1,64 @@
+import { AttributeMetadataDictionary, setAttributes } from './attribute-operator-isolation';
+
+type Calls = [string, string | null][];
+
+/** A setAttribute spy plus a fresh metadata map. */
+function setup() {
+  const calls: Calls = [];
+  const metadata = new Map<symbol, AttributeMetadataDictionary<string>>();
+  const setAttribute = (name: string, value: string | null) => { calls.push([name, value]); };
+  return { calls, metadata, setAttribute };
+}
+
+describe('setAttributes', () => {
+  it('sets a string attribute and records it in the metadata map', () => {
+    const { calls, metadata, setAttribute } = setup();
+    const symbol = Symbol();
+    setAttributes(setAttribute, metadata, symbol, { id: 'x' });
+    expect(calls).toEqual([['id', 'x']]);
+    expect(metadata.get(symbol)).toEqual({ id: 'x' });
+  });
+
+  it('coerces booleans to "" / null and other values to strings', () => {
+    const { calls, metadata, setAttribute } = setup();
+    const mixed: Record<string, unknown> = { a: true, b: false, c: 0, d: null };
+    setAttributes(setAttribute, metadata, Symbol(), mixed);
+    expect(calls).toEqual([
+      ['a', ''],     // boolean true → present with empty value
+      ['b', null],   // boolean false → removed
+      ['c', '0'],    // number → string
+      ['d', null],   // explicit null → removed
+    ]);
+  });
+
+  it('nulls out attributes removed since the previous object', () => {
+    const { calls, metadata, setAttribute } = setup();
+    const symbol = Symbol();
+    setAttributes(setAttribute, metadata, symbol, { a: '1', b: '2' });
+    calls.length = 0;
+    setAttributes(setAttribute, metadata, symbol, { a: '1' }, { a: '1', b: '2' }); // b dropped
+    expect(calls).toEqual(expect.arrayContaining([['a', '1'], ['b', null]]));
+    expect(metadata.get(symbol)).toEqual({ a: '1', b: null });
+  });
+
+  it('lets the earliest operator win when several set the same attribute', () => {
+    const { calls, metadata, setAttribute } = setup();
+    const first = Symbol('first');
+    const second = Symbol('second');
+    setAttributes(setAttribute, metadata, first, { color: 'red' });
+    calls.length = 0;
+    setAttributes(setAttribute, metadata, second, { color: 'blue' });
+    expect(calls).toEqual([['color', 'red']]); // first operator (inserted first) keeps priority
+  });
+
+  it('falls through to a lower-priority operator when the winner removes its value', () => {
+    const { calls, metadata, setAttribute } = setup();
+    const first = Symbol('first');
+    const second = Symbol('second');
+    setAttributes(setAttribute, metadata, first, { color: 'red' });
+    setAttributes(setAttribute, metadata, second, { color: 'blue' });
+    calls.length = 0;
+    setAttributes(setAttribute, metadata, first, {}, { color: 'red' }); // first drops color
+    expect(calls).toEqual([['color', 'blue']]); // second operator's value now shows through
+  });
+});

--- a/src/lib/rxfm/attributes/attributes.test.ts
+++ b/src/lib/rxfm/attributes/attributes.test.ts
@@ -1,0 +1,63 @@
+import { BehaviorSubject } from 'rxjs';
+import { attribute, attributes } from './attributes';
+import { Div, Input } from '../components';
+import { Component, ElementType } from '../components/component';
+
+function render<T extends ElementType>(component: Component<T>): T {
+  let element!: T;
+  component.subscribe(el => { element = el; });
+  return element;
+}
+
+describe('attribute', () => {
+  it('sets an individual attribute via the proxy', () => {
+    const element = render(Div('').pipe(attribute.id('app')));
+    expect(element.getAttribute('id')).toBe('app');
+  });
+
+  it('updates an attribute from an observable and removes it on null', () => {
+    const title = new BehaviorSubject<string | null>('hello');
+    const element = render(Div('').pipe(attribute.title(title)));
+    expect(element.getAttribute('title')).toBe('hello');
+    title.next(null);
+    expect(element.hasAttribute('title')).toBe(false);
+  });
+
+  it('renders a boolean attribute as present/absent', () => {
+    const disabled = new BehaviorSubject(true);
+    const element = render(Input().pipe(attribute('disabled', disabled)));
+    expect(element.getAttribute('disabled')).toBe('');
+    disabled.next(false);
+    expect(element.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('writes the value property (not attribute) for inputs', () => {
+    const element = render(Input().pipe(attribute('value', 'typed'))) as HTMLInputElement;
+    expect(element.value).toBe('typed');
+  });
+
+  it('builds an attribute value from a tagged template', () => {
+    const name = new BehaviorSubject('world');
+    const element = render(Div('').pipe(attribute.title`hello ${name}`));
+    expect(element.getAttribute('title')).toBe('hello world');
+    name.next('there');
+    expect(element.getAttribute('title')).toBe('hello there');
+  });
+});
+
+describe('attributes', () => {
+  it('sets multiple attributes from a static dictionary', () => {
+    const element = render(Div('').pipe(attributes({ id: 'app', title: 'hi' })));
+    expect(element.getAttribute('id')).toBe('app');
+    expect(element.getAttribute('title')).toBe('hi');
+  });
+
+  it('sets and diffs attributes from an observable dictionary', () => {
+    const dict = new BehaviorSubject<Record<string, string>>({ id: 'app', title: 'hi' });
+    const element = render(Div('').pipe(attributes(dict)));
+    expect(element.getAttribute('title')).toBe('hi');
+    dict.next({ id: 'app' }); // title dropped → removed
+    expect(element.hasAttribute('title')).toBe(false);
+    expect(element.getAttribute('id')).toBe('app');
+  });
+});

--- a/src/lib/rxfm/attributes/classes.test.ts
+++ b/src/lib/rxfm/attributes/classes.test.ts
@@ -1,0 +1,53 @@
+import { BehaviorSubject, of } from 'rxjs';
+import { classes } from './classes';
+import { Div } from '../components';
+import { Component, ElementType } from '../components/component';
+
+/** Subscribe to a component and return its element (kept subscribed for live updates). */
+function render<T extends ElementType>(component: Component<T>): T {
+  let element!: T;
+  component.subscribe(el => { element = el; });
+  return element;
+}
+
+const classNames = (element: ElementType) => Array.from(element.classList).sort();
+
+describe('classes', () => {
+  it('adds static class names', () => {
+    const element = render(Div('').pipe(classes('a', 'b')));
+    expect(classNames(element)).toEqual(['a', 'b']);
+  });
+
+  it('splits space-separated class strings', () => {
+    const element = render(Div('').pipe(classes('a b')));
+    expect(classNames(element)).toEqual(['a', 'b']);
+  });
+
+  it('adds class names from an observable, swapping as it emits', () => {
+    const className = new BehaviorSubject('a');
+    const element = render(Div('').pipe(classes(className)));
+    expect(classNames(element)).toEqual(['a']);
+    className.next('b');
+    expect(classNames(element)).toEqual(['b']);
+  });
+
+  it('accepts an observable emitting an array of class names', () => {
+    const element = render(Div('').pipe(classes(of(['a', 'b']))));
+    expect(classNames(element)).toEqual(['a', 'b']);
+  });
+
+  it('removes a class when its value becomes falsy', () => {
+    const className = new BehaviorSubject<string | null>('a');
+    const element = render(Div('').pipe(classes(className)));
+    className.next(null);
+    expect(classNames(element)).toEqual([]);
+  });
+
+  it('does not remove a class still claimed by another operator', () => {
+    const dynamic = new BehaviorSubject<string | null>('shared');
+    const element = render(Div('').pipe(classes('shared'), classes(dynamic)));
+    expect(classNames(element)).toEqual(['shared']);
+    dynamic.next(null); // dynamic operator drops it, but the static operator still holds it
+    expect(classNames(element)).toEqual(['shared']);
+  });
+});

--- a/src/lib/rxfm/attributes/styles.test.ts
+++ b/src/lib/rxfm/attributes/styles.test.ts
@@ -1,0 +1,57 @@
+import { BehaviorSubject } from 'rxjs';
+import { style, styles } from './styles';
+import { Div } from '../components';
+import { Component, ElementType } from '../components/component';
+
+function render<T extends ElementType>(component: Component<T>): T {
+  let element!: T;
+  component.subscribe(el => { element = el; });
+  return element;
+}
+
+describe('style', () => {
+  it('sets an individual style via the proxy', () => {
+    const element = render(Div('').pipe(style.color('red')));
+    expect(element.style.color).toBe('red');
+  });
+
+  it('updates a style from an observable', () => {
+    const color = new BehaviorSubject('red');
+    const element = render(Div('').pipe(style.color(color)));
+    expect(element.style.color).toBe('red');
+    color.next('blue');
+    expect(element.style.color).toBe('blue');
+  });
+
+  it('removes a style when the value becomes falsy', () => {
+    const color = new BehaviorSubject<string | null>('red');
+    const element = render(Div('').pipe(style.color(color)));
+    color.next(null);
+    expect(element.style.color).toBe('');
+  });
+
+  it('builds a style value from a tagged template', () => {
+    const width = new BehaviorSubject(10);
+    const element = render(Div('').pipe(style.width`${width}px`));
+    expect(element.style.width).toBe('10px');
+    width.next(20);
+    expect(element.style.width).toBe('20px');
+  });
+});
+
+describe('styles', () => {
+  it('sets multiple styles from a static dictionary', () => {
+    const element = render(Div('').pipe(styles({ color: 'red', width: '10px' })));
+    expect(element.style.color).toBe('red');
+    expect(element.style.width).toBe('10px');
+  });
+
+  it('sets and diffs styles from an observable dictionary', () => {
+    const dict = new BehaviorSubject<{ color?: string; width?: string }>({ color: 'red', width: '10px' });
+    const element = render(Div('').pipe(styles(dict)));
+    expect(element.style.color).toBe('red');
+    dict.next({ color: 'blue' }); // width dropped from the object → removed
+    expect(element.style.color).toBe('blue');
+    expect(element.style.width).toBe('');
+  });
+});

--- a/src/lib/rxfm/attributes/styles.ts
+++ b/src/lib/rxfm/attributes/styles.ts
@@ -32,8 +32,9 @@ export type StyleObject = AttributeMetadataObject<StyleKeys, StyleType>;
  * Apply a style to an element.
  */
 const setStyle = (element: ElementType, key: StyleKeys, value: string | null) => {
-  if (element.style[key] || null !== value || null) { // If style has changed (coercing empty string to null).
-    element.style[key] = (value || null) as string; // Set style or remove by setting to null.
+  const nextValue = (value as string) || null; // Coerce empty string / falsy to null.
+  if ((element.style[key] || null) !== nextValue) { // Only write when the value has actually changed.
+    element.style[key] = nextValue as string; // Set style or remove by setting to null.
   }
 };
 

--- a/src/lib/rxfm/children/child-differ.test.ts
+++ b/src/lib/rxfm/children/child-differ.test.ts
@@ -1,0 +1,128 @@
+import { childDiffer, IChildDiff } from './child-differ';
+import { ChildElement } from './children';
+
+/**
+ * Create a distinct element whose text content is its label, so the order of a parent's children
+ * can be read back as a list of labels.
+ */
+function element(label: string): HTMLElement {
+  const el = document.createElement('div');
+  el.textContent = label;
+  return el;
+}
+
+/** An empty parent element to apply diffs to. */
+function parentElement(): HTMLElement {
+  return document.createElement('div');
+}
+
+/** Read a parent's current child order back as a list of labels. */
+function labelsOf(parent: HTMLElement): string[] {
+  return Array.from(parent.childNodes).map(node => node.textContent ?? '');
+}
+
+/**
+ * Apply a diff to a parent exactly as the children operator does: remove the removed nodes, then
+ * insert each updated node before its reference (or append it). Inserting a node already in the
+ * parent moves it, which is how reordering happens.
+ */
+function applyDiff(parent: HTMLElement, diff: IChildDiff): void {
+  diff.removed.forEach(node => parent.removeChild(node));
+  diff.updated.forEach(({ node, insertBefore }) => {
+    if (insertBefore) {
+      parent.insertBefore(node, insertBefore);
+    } else {
+      parent.appendChild(node);
+    }
+  });
+}
+
+/** All permutations of an array. */
+function permutations<T>(items: T[]): T[][] {
+  if (items.length <= 1) return [items];
+  return items.flatMap((item, i) =>
+    permutations([...items.slice(0, i), ...items.slice(i + 1)]).map(rest => [item, ...rest]),
+  );
+}
+
+describe('childDiffer', () => {
+  it('reports no updates or removals when the children are unchanged', () => {
+    const [a, b, c] = [element('a'), element('b'), element('c')];
+    const diff = childDiffer([a, b, c], [a, b, c]);
+    expect(diff.updated).toEqual([]);
+    expect(diff.removed).toEqual([]);
+  });
+
+  it('reports added nodes with the node to insert them before', () => {
+    const [a, b, c] = [element('a'), element('b'), element('c')];
+    const diff = childDiffer([a, c], [a, b, c]); // Insert b between a and c.
+    expect(diff.removed).toEqual([]);
+    expect(diff.updated).toEqual([{ node: b, insertBefore: c }]);
+  });
+
+  it('appends added nodes with no reference when they go at the end', () => {
+    const [a, b] = [element('a'), element('b')];
+    const diff = childDiffer([a], [a, b]);
+    expect(diff.updated).toEqual([{ node: b, insertBefore: undefined }]);
+  });
+
+  it('reports removed nodes', () => {
+    const [a, b, c] = [element('a'), element('b'), element('c')];
+    const diff = childDiffer([a, b, c], [a, c]);
+    expect(diff.updated).toEqual([]);
+    expect(diff.removed).toEqual([b]);
+  });
+
+  // Regression: the previous heuristic kept both a and c in place even though they had swapped
+  // relative order, producing [a, c, b] instead of [c, a, b].
+  it('handles a rotation that swaps the relative order of kept nodes', () => {
+    const [a, b, c] = [element('a'), element('b'), element('c')];
+    const parent = parentElement();
+    [a, b, c].forEach(el => parent.appendChild(el));
+    applyDiff(parent, childDiffer([a, b, c], [c, a, b]));
+    expect(labelsOf(parent)).toEqual(['c', 'a', 'b']);
+  });
+
+  // Regression: a simple two-element swap previously produced no moves at all.
+  it('handles a simple swap of two nodes', () => {
+    const [a, b] = [element('a'), element('b')];
+    const parent = parentElement();
+    [a, b].forEach(el => parent.appendChild(el));
+    applyDiff(parent, childDiffer([a, b], [b, a]));
+    expect(labelsOf(parent)).toEqual(['b', 'a']);
+  });
+
+  it('moves only the nodes that are out of order, keeping the longest in-order run in place', () => {
+    const [a, b, c, d] = [element('a'), element('b'), element('c'), element('d')];
+    // a, b, c stay in order; only d moves to the front.
+    const diff = childDiffer([a, b, c, d], [d, a, b, c]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.updated).toEqual([{ node: d, insertBefore: a }]);
+  });
+
+  it('transforms old into new for every add / remove / reorder permutation of up to five nodes', () => {
+    const base = ['a', 'b', 'c', 'd', 'e'];
+    let caseCount = 0;
+
+    for (let oldLength = 1; oldLength <= base.length; oldLength++) {
+      const universe = base.slice(0, Math.min(oldLength + 1, base.length)); // Allow one extra node to be added.
+      const elements = new Map(universe.map(label => [label, element(label)]));
+      const oldLabels = base.slice(0, oldLength);
+      const oldChildren = oldLabels.map(label => elements.get(label)!);
+
+      for (let mask = 0; mask < (1 << universe.length); mask++) {
+        const subset = universe.filter((_, i) => mask & (1 << i)); // Every subset of the universe...
+        for (const newLabels of permutations(subset)) { // ...in every order.
+          caseCount++;
+          const parent = parentElement();
+          oldChildren.forEach(el => parent.appendChild(el)); // Re-attach the shared elements to a fresh parent.
+          const newChildren = newLabels.map(label => elements.get(label)!) as ChildElement[];
+          applyDiff(parent, childDiffer(oldChildren, newChildren));
+          expect(labelsOf(parent)).toEqual(newLabels);
+        }
+      }
+    }
+
+    expect(caseCount).toBeGreaterThan(700); // Sanity check that the sweep actually ran.
+  });
+});

--- a/src/lib/rxfm/children/child-differ.ts
+++ b/src/lib/rxfm/children/child-differ.ts
@@ -29,7 +29,52 @@ export interface IChildDiff {
 }
 
 /**
+ * Given a sequence of numbers, return the set of array positions which form a longest
+ * strictly-increasing subsequence. Computed in O(n log n) via patience sorting, keeping predecessor
+ * links so the subsequence itself can be reconstructed.
+ */
+function longestIncreasingSubsequence(sequence: number[]): Set<number> {
+  const kept = new Set<number>();
+  if (sequence.length === 0) return kept;
+
+  const predecessors = new Array<number>(sequence.length); // predecessors[i] = previous position in the subsequence ending at i.
+  const tails: number[] = []; // tails[k] = position of the smallest tail value of an increasing subsequence of length k + 1.
+
+  for (let i = 0; i < sequence.length; i++) {
+    // Binary search for the first tail whose value is >= sequence[i] (strictly increasing).
+    let low = 0;
+    let high = tails.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      if (sequence[tails[mid]] < sequence[i]) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    predecessors[i] = low > 0 ? tails[low - 1] : -1; // The position this one extends, if any.
+    if (low === tails.length) {
+      tails.push(i); // Extends the longest subsequence found so far.
+    } else {
+      tails[low] = i; // Improves the tail of an existing length.
+    }
+  }
+
+  // Walk the predecessor links back from the end of the longest subsequence to collect its positions.
+  for (let k = tails[tails.length - 1]; k >= 0; k = predecessors[k]) {
+    kept.add(k);
+  }
+  return kept;
+}
+
+/**
  * Find the difference between two arrays of nodes.
+ *
+ * Nodes are matched by identity. Any node present in both arrays but in a different relative order
+ * may need to move; to minimise DOM operations we keep the *longest* run of common nodes that is
+ * already in the correct relative order in place (the longest increasing subsequence of their old
+ * positions) and only move the rest. Runs in O(n log n).
+ *
  * @returns An object containing all updated (and added) nodes as well as all removed nodes in the new children array
  * compared to the old children array.
  */
@@ -37,60 +82,36 @@ export function childDiffer(
   oldChildren: ChildElement[],
   newChildren: ChildElement[]
 ): IChildDiff {
-  const oldSet = new Set(oldChildren); // Create sets of both new and old children.
   const newSet = new Set(newChildren);
+  const removed = oldChildren.filter(node => !newSet.has(node)); // Nodes no longer present.
 
-  // Find the common nodes between the old and new children, ordered as they are in both the new and old arrays.
-  const remainingOldOrder = oldChildren.filter(node => newSet.has(node));
-  const remainingNewOrder = newChildren.filter(node => oldSet.has(node));
+  // Map each old node to its index so the new order can be described as a sequence of old positions.
+  const oldIndexByNode = new Map(oldChildren.map((node, i) => [node, i]));
 
-  // Find if the common nodes have not changed order between the new and old arrays.
-  const orderUnchanged = remainingNewOrder.every(
-    (node, i) => remainingOldOrder[i] === node
-  );
+  // The nodes common to both states, in their new order, and their corresponding old positions.
+  const commonNodes = newChildren.filter(node => oldIndexByNode.has(node));
+  const oldPositions = commonNodes.map(node => oldIndexByNode.get(node)!);
 
-  let unchangedNodes: Set<ChildElement>; // Create a set of all nodes which are common and have not changed order.
-  if (orderUnchanged) {
-    unchangedNodes = new Set(remainingNewOrder); // If order has not changed, create set from common nodes.
+  // The common nodes whose old positions form a longest increasing subsequence are already in the
+  // correct relative order and can stay put; every other node will be (re)inserted.
+  const keptPositions = longestIncreasingSubsequence(oldPositions);
+  const keptNodes = new Set<ChildElement>();
+  keptPositions.forEach(position => keptNodes.add(commonNodes[position]));
 
-  } else { // Otherwise find nodes whose order has not changed.
-    const oldNodeAndNext = new Map( // Create a map of each common node to its next common node in the old order.
-      remainingOldOrder.map((node, i) => [node, remainingOldOrder[i + 1]])
-    );
-    const newElementsAndIndex = new Map( // Create a map of each common node to its index in the new order.
-      remainingNewOrder.map((node, i) => [node, i])
-    );
-
-    const reordered = new Set( // Create a set of all common nodes which have changed order.
-      remainingNewOrder.filter((node, i) => {
-        const oldNext = oldNodeAndNext.get(node); // Get the node which used to follow this one in the old order.
-        const newIndexOfNext = (oldNext && newElementsAndIndex.get(oldNext)) || Infinity; // Find the new index of that node.
-        return newIndexOfNext < i; // Node is reordered if the old next element now comes before this element.
-      })
-    );
-
-    unchangedNodes = new Set( // Unchanged nodes is inverse of reordered nodes.
-      remainingNewOrder.filter(node => !reordered.has(node))
-    );
-  }
-
-  // Create an array of node updates (an update is a node and the node to insert it before if applicable).
+  // Walk the new children from right to left. Each kept node becomes the reference that following
+  // (new or moved) nodes are inserted before; nodes after the last kept node are appended (the
+  // insertBefore reference starts undefined and is overwritten by each kept node encountered).
   let insertBefore: ChildElement | undefined;
   const updated: INodeUpdate[] = [];
-  for (let i = newChildren.length - 1; i >= 0; i--) { // Loop through the new nodes in reverse order
+  for (let i = newChildren.length - 1; i >= 0; i--) {
     const node = newChildren[i];
-    if (unchangedNodes.has(node)) { // If the current node already existed and has not changed order:
-      // Any future nodes should be inserted before this one so store as the current insert before reference. This will
-      // start as undefined so if no unchanged nodes have yet been passed then nodes will be inserted at the end, this
-      // value will be overwritten by any future unchanged nodes.
+    if (keptNodes.has(node)) {
       insertBefore = node;
-    } else { // If this is a new node or has changed order:
-      updated.push({ node, insertBefore }); // Add to the updated array along with the node to insert before if present.
+    } else {
+      updated.push({ node, insertBefore });
     }
   }
-  updated.reverse(); // Reverse the updated array to put it in the correct order of the new nodes.
-
-  const removed = oldChildren.filter(child => !newSet.has(child)); // Find any nodes which have been removed.
+  updated.reverse(); // Put the updates back into new-children order.
 
   return { updated, removed };
 }

--- a/src/lib/rxfm/children/children-operator-isolation.test.ts
+++ b/src/lib/rxfm/children/children-operator-isolation.test.ts
@@ -1,0 +1,105 @@
+import {
+  ChildrenBlockMetadata,
+  registerChildrenBlockMetadata,
+  addChildrenToMetadata,
+  removeChildrenFromMetadata,
+} from './children-operator-isolation';
+
+const a = Symbol('a');
+const b = Symbol('b');
+const c = Symbol('c');
+
+describe('registerChildrenBlockMetadata', () => {
+  it('prepends a start-aligned block', () => {
+    const existing: ChildrenBlockMetadata[] = [{ symbol: a, length: 1 }];
+    expect(registerChildrenBlockMetadata(existing, b, false)).toEqual([
+      { symbol: b, length: 0 },
+      { symbol: a, length: 1 },
+    ]);
+  });
+
+  it('appends an end-aligned block', () => {
+    const existing: ChildrenBlockMetadata[] = [{ symbol: a, length: 1 }];
+    expect(registerChildrenBlockMetadata(existing, b, true)).toEqual([
+      { symbol: a, length: 1 },
+      { symbol: b, length: 0 },
+    ]);
+  });
+
+  it('returns the same array reference when the block already exists', () => {
+    const existing: ChildrenBlockMetadata[] = [{ symbol: a, length: 1 }];
+    expect(registerChildrenBlockMetadata(existing, a, false)).toBe(existing);
+  });
+});
+
+describe('addChildrenToMetadata', () => {
+  it('increments the target block length and returns the index just past its existing children', () => {
+    const metadata: ChildrenBlockMetadata[] = [
+      { symbol: a, length: 2 },
+      { symbol: b, length: 3 },
+    ];
+    const { newMetadata, insertBeforeIndex } = addChildrenToMetadata(metadata, a);
+    expect(newMetadata).toEqual([
+      { symbol: a, length: 3 },
+      { symbol: b, length: 3 },
+    ]);
+    expect(insertBeforeIndex).toBe(2); // Block a's 2 existing children occupy 0,1 → insert at 2.
+  });
+
+  it('offsets the insertion index by the lengths of all preceding blocks', () => {
+    const metadata: ChildrenBlockMetadata[] = [
+      { symbol: a, length: 2 },
+      { symbol: b, length: 3 },
+    ];
+    const { insertBeforeIndex } = addChildrenToMetadata(metadata, b);
+    expect(insertBeforeIndex).toBe(5); // 2 (block a) + 3 (block b's existing) → append at 5.
+  });
+
+  it('adds multiple children at once', () => {
+    const metadata: ChildrenBlockMetadata[] = [{ symbol: a, length: 0 }];
+    const { newMetadata, insertBeforeIndex } = addChildrenToMetadata(metadata, a, false, 4);
+    expect(newMetadata).toEqual([{ symbol: a, length: 4 }]);
+    expect(insertBeforeIndex).toBe(0); // Empty block → first child goes at index 0.
+  });
+
+  it('does not mutate the input metadata', () => {
+    const metadata: ChildrenBlockMetadata[] = [{ symbol: a, length: 2 }];
+    addChildrenToMetadata(metadata, a);
+    expect(metadata).toEqual([{ symbol: a, length: 2 }]);
+  });
+
+  // Regression: previously the block index was taken from currentMetadata, so a block registered
+  // inside this call (absent from currentMetadata) produced index -1 and threw.
+  it('handles a block that is only registered within the call', () => {
+    const metadata: ChildrenBlockMetadata[] = [{ symbol: a, length: 1 }];
+    const { newMetadata, insertBeforeIndex } = addChildrenToMetadata(metadata, b, false);
+    expect(newMetadata).toEqual([
+      { symbol: b, length: 1 },
+      { symbol: a, length: 1 },
+    ]);
+    expect(insertBeforeIndex).toBe(0); // start-aligned new block: its child goes at the front.
+  });
+});
+
+describe('removeChildrenFromMetadata', () => {
+  it('decrements the target block length', () => {
+    const metadata: ChildrenBlockMetadata[] = [{ symbol: a, length: 3 }];
+    expect(removeChildrenFromMetadata(metadata, a, 2)).toEqual([{ symbol: a, length: 1 }]);
+  });
+
+  it('never decrements below zero', () => {
+    const metadata: ChildrenBlockMetadata[] = [{ symbol: a, length: 1 }];
+    expect(removeChildrenFromMetadata(metadata, a, 5)).toEqual([{ symbol: a, length: 0 }]);
+  });
+
+  it('returns the metadata unchanged when the block is absent', () => {
+    const metadata: ChildrenBlockMetadata[] = [{ symbol: a, length: 1 }];
+    expect(removeChildrenFromMetadata(metadata, c, 1)).toBe(metadata);
+  });
+
+  it('does not mutate the input metadata', () => {
+    const metadata: ChildrenBlockMetadata[] = [{ symbol: a, length: 3 }];
+    removeChildrenFromMetadata(metadata, a, 1);
+    expect(metadata).toEqual([{ symbol: a, length: 3 }]);
+  });
+});

--- a/src/lib/rxfm/children/children-operator-isolation.ts
+++ b/src/lib/rxfm/children/children-operator-isolation.ts
@@ -52,8 +52,9 @@ export function addChildrenToMetadata(
   let newMetadata = registerChildrenBlockMetadata(currentMetadata, blockSymbol, end);
   // Clone metadata if it was not already.
   newMetadata = newMetadata === currentMetadata ? [...newMetadata] : newMetadata;
-  // Find index of our block.
-  const index = currentMetadata.findIndex((({ symbol }) => symbol === blockSymbol));
+  // Find index of our block. Derived from newMetadata (not currentMetadata) so it is correct even
+  // when the block was only just registered above and so is absent from currentMetadata.
+  const index = newMetadata.findIndex((({ symbol }) => symbol === blockSymbol));
   // Find element to insert before if available.
   const insertBeforeIndex = newMetadata.slice(0, index + 1).reduce((count, { length }) => count + length, 0);
   // Update metadata by incrementing the block length by the number of added elements.

--- a/src/lib/rxfm/children/children.test.ts
+++ b/src/lib/rxfm/children/children.test.ts
@@ -1,0 +1,67 @@
+import { BehaviorSubject, of } from 'rxjs';
+import { children, lastChildren } from './children';
+import { Div, Span } from '../components';
+import { Component, ElementType } from '../components/component';
+
+function render<T extends ElementType>(component: Component<T>): T {
+  let element!: T;
+  component.subscribe(el => { element = el; });
+  return element;
+}
+
+describe('children', () => {
+  it('adds a string as a text node', () => {
+    expect(render(Div().pipe(children('hello'))).textContent).toBe('hello');
+  });
+
+  it('coerces a number to text', () => {
+    expect(render(Div().pipe(children(5))).textContent).toBe('5');
+  });
+
+  it('renders nothing for null/false/undefined children', () => {
+    expect(render(Div().pipe(children(null, false, undefined))).childNodes.length).toBe(0);
+  });
+
+  it('appends a component child as an element', () => {
+    const element = render(Div().pipe(children(Span('x'))));
+    expect(element.querySelector('span')?.textContent).toBe('x');
+  });
+
+  it('calls a function child to create its component', () => {
+    const element = render(Div().pipe(children(() => Span('y'))));
+    expect(element.querySelector('span')?.textContent).toBe('y');
+  });
+
+  it('updates a text node when an observable child emits', () => {
+    const child = new BehaviorSubject('a');
+    const element = render(Div().pipe(children(child)));
+    expect(element.textContent).toBe('a');
+    child.next('b');
+    expect(element.textContent).toBe('b');
+  });
+
+  it('swaps a text node for an element when an observable child changes type', () => {
+    const span = document.createElement('span');
+    span.textContent = 'e';
+    const child = new BehaviorSubject<string | HTMLElement>('text');
+    const element = render(Div().pipe(children(child)));
+    expect(element.textContent).toBe('text');
+    child.next(span);
+    expect(element.querySelector('span')).toBe(span);
+  });
+
+  it('renders an element array emitted by an observable', () => {
+    const spans = [document.createElement('span'), document.createElement('span')];
+    spans[0].textContent = '1';
+    spans[1].textContent = '2';
+    const element = render(Div().pipe(children(of(spans))));
+    expect(Array.from(element.children)).toEqual(spans);
+  });
+});
+
+describe('lastChildren', () => {
+  it('places its children after those of the children operator', () => {
+    const element = render(Div().pipe(children('a'), lastChildren('b')));
+    expect(element.textContent).toBe('ab');
+  });
+});

--- a/src/lib/rxfm/components/add-to-view.test.ts
+++ b/src/lib/rxfm/components/add-to-view.test.ts
@@ -1,0 +1,38 @@
+import { BehaviorSubject } from 'rxjs';
+import { addToView } from './add-to-view';
+import { ElementType } from './component';
+
+describe('addToView', () => {
+  it('appends the component element to the host', () => {
+    const host = document.createElement('div');
+    const element = document.createElement('span');
+    addToView(new BehaviorSubject<ElementType>(element), host);
+    expect(host.children[0]).toBe(element);
+  });
+
+  it('replaces the previous element when the component emits a new one', () => {
+    const host = document.createElement('div');
+    const first = document.createElement('span');
+    const second = document.createElement('p');
+    const component = new BehaviorSubject<ElementType>(first);
+    addToView(component, host);
+
+    component.next(second);
+    expect(host.children.length).toBe(1); // replaced, not appended
+    expect(host.children[0]).toBe(second);
+  });
+
+  it('removes the element and stops updating once the remove function is called', () => {
+    const host = document.createElement('div');
+    const first = document.createElement('span');
+    const second = document.createElement('p');
+    const component = new BehaviorSubject<ElementType>(first);
+    const remove = addToView(component, host);
+
+    remove();
+    expect(host.children.length).toBe(0);
+
+    component.next(second); // subscription torn down → no re-add
+    expect(host.children.length).toBe(0);
+  });
+});

--- a/src/lib/rxfm/components/add-to-view.test.ts
+++ b/src/lib/rxfm/components/add-to-view.test.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, NEVER } from 'rxjs';
 import { addToView } from './add-to-view';
 import { ElementType } from './component';
 
@@ -33,6 +33,13 @@ describe('addToView', () => {
     expect(host.children.length).toBe(0);
 
     component.next(second); // subscription torn down → no re-add
+    expect(host.children.length).toBe(0);
+  });
+
+  it('does not throw when removed before the component has emitted', () => {
+    const host = document.createElement('div');
+    const remove = addToView(NEVER, host); // never emits an element
+    expect(() => remove()).not.toThrow();
     expect(host.children.length).toBe(0);
   });
 });

--- a/src/lib/rxfm/components/add-to-view.ts
+++ b/src/lib/rxfm/components/add-to-view.ts
@@ -16,7 +16,7 @@ export function addToView(
   component: Component,
   host: ElementType = document.body,
 ): RemoveComponent {
-  let oldNode: ElementType; // The node already in the view, if it exists.
+  let oldNode: ElementType | undefined; // The node already in the view, if it exists.
   const subscription = component.pipe(
     distinctUntilChanged(),
   ).subscribe(element => {
@@ -30,6 +30,6 @@ export function addToView(
 
   return () => { // Return a function to remove the node and clean up subscription.
     subscription.unsubscribe();
-    host.removeChild(oldNode);
+    if (oldNode) host.removeChild(oldNode); // Guard: the component may never have emitted.
   };
 }

--- a/src/lib/rxfm/components/component-factories.test.ts
+++ b/src/lib/rxfm/components/component-factories.test.ts
@@ -1,0 +1,62 @@
+import { of, Subject } from 'rxjs';
+import { componentFunction, componentOperator, sideEffect, Component, ElementType } from './component';
+import { Div, Span } from './html';
+
+function render<T extends ElementType>(component: Component<T>): T {
+  let element!: T;
+  component.subscribe(el => { element = el; });
+  return element;
+}
+
+describe('componentFunction', () => {
+  it('creates a fresh element per subscription (deferred)', () => {
+    const create = componentFunction(() => document.createElement('div'));
+    const component = create('hi');
+    expect(render(component)).not.toBe(render(component)); // defer → new element each time
+  });
+
+  it('adds the passed children', () => {
+    const create = componentFunction(() => document.createElement('div'));
+    expect(render(create('hello')).textContent).toBe('hello');
+  });
+});
+
+describe('componentOperator', () => {
+  it('runs the effect against the element and re-emits the same element', () => {
+    const operator = componentOperator<HTMLElement, void>(element => {
+      element.setAttribute('data-x', '1');
+      return of(undefined);
+    });
+    const base = Div();
+    const baseElement = render(base);
+    const operated = render(base.pipe(operator));
+    expect(operated.getAttribute('data-x')).toBe('1');
+    // The operator is mono-type: it re-emits the element it was given, not a new one.
+    expect(operated).toBeInstanceOf(HTMLDivElement);
+    expect(baseElement).toBeInstanceOf(HTMLDivElement);
+  });
+});
+
+describe('sideEffect', () => {
+  it('injects an observable and runs its effect without changing the element', () => {
+    const source = new Subject<number>();
+    const effect = jest.fn();
+    const element = render(Div().pipe(sideEffect(source, effect)));
+    expect(element).toBeInstanceOf(HTMLDivElement);
+    source.next(5);
+    expect(effect).toHaveBeenCalledWith(5);
+  });
+
+  it('injects an observable with no effect and still emits the element', () => {
+    const source = new Subject<number>();
+    const element = render(Div().pipe(sideEffect(source)));
+    expect(element).toBeInstanceOf(HTMLDivElement);
+  });
+});
+
+describe('componentCreator', () => {
+  it('throws if a non-template array of children is passed directly', () => {
+    // A real array (not a tagged-template strings array) containing a non-string is rejected.
+    expect(() => Div([Span()] as never)).toThrow(TypeError);
+  });
+});

--- a/src/lib/rxfm/events.test.ts
+++ b/src/lib/rxfm/events.test.ts
@@ -1,0 +1,69 @@
+import { BehaviorSubject } from 'rxjs';
+import { event, events } from './events';
+import { Div } from './components';
+import { Component, ElementType } from './components/component';
+
+function render<T extends ElementType>(component: Component<T>): T {
+  let element!: T;
+  component.subscribe(el => { element = el; });
+  return element;
+}
+
+describe('event', () => {
+  it('invokes a handler registered via the proxy property form', () => {
+    const handler = jest.fn();
+    const element = render(Div('').pipe(event.click(handler)));
+    element.dispatchEvent(new MouseEvent('click'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes a handler registered via the generic (type, handler) form', () => {
+    const handler = jest.fn();
+    const element = render(Div('').pipe(event('click', handler)));
+    element.dispatchEvent(new MouseEvent('click'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the event object to the handler', () => {
+    let received: Event | undefined;
+    const element = render(Div('').pipe(event.click(ev => { received = ev; })));
+    const dispatched = new MouseEvent('click');
+    element.dispatchEvent(dispatched);
+    expect(received).toBe(dispatched);
+  });
+
+  it('uses the latest handler emitted by an observable', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const handler = new BehaviorSubject<(ev: Event) => void>(first);
+    const element = render(Div('').pipe(event.click(handler)));
+
+    element.dispatchEvent(new MouseEvent('click'));
+    handler.next(second);
+    element.dispatchEvent(new MouseEvent('click'));
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('only fires for the registered event type', () => {
+    const handler = jest.fn();
+    const element = render(Div('').pipe(event.click(handler)));
+    element.dispatchEvent(new MouseEvent('mouseover'));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('events', () => {
+  it('registers multiple handlers from a map', () => {
+    const onClick = jest.fn();
+    const onMouseover = jest.fn();
+    const element = render(Div('').pipe(events({ click: onClick, mouseover: onMouseover })));
+
+    element.dispatchEvent(new MouseEvent('click'));
+    element.dispatchEvent(new MouseEvent('mouseover'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onMouseover).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/rxfm/map-to-components.test.ts
+++ b/src/lib/rxfm/map-to-components.test.ts
@@ -1,0 +1,122 @@
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { finalize, map } from 'rxjs/operators';
+import { mapToComponents } from './map-to-components';
+import { Div } from './components';
+import { ElementType } from './components/component';
+
+interface Item { id: number; label: string; }
+
+function collect<T>(observable: Observable<T>): { values: T[]; subscription: Subscription } {
+  const values: T[] = [];
+  const subscription = observable.subscribe(value => values.push(value));
+  return { values, subscription };
+}
+
+/** The most recent emission, cast to an element array. */
+function lastRender<T>(collected: { values: T[] }): ElementType[] {
+  return collected.values[collected.values.length - 1] as unknown as ElementType[];
+}
+
+/** A creation function rendering each item's label as the element's text. */
+const labelComponent = (item$: Observable<Item>) => Div(item$.pipe(map(item => item.label)));
+
+describe('mapToComponents', () => {
+  it('starts with an empty array', () => {
+    const source = new BehaviorSubject<Item[]>([{ id: 1, label: 'a' }]);
+    expect(collect(source.pipe(mapToComponents(labelComponent, 'id'))).values[0]).toEqual([]);
+  });
+
+  it('renders one element per item, in order', () => {
+    const source = new BehaviorSubject<Item[]>([
+      { id: 1, label: 'a' },
+      { id: 2, label: 'b' },
+    ]);
+    const collected = collect(source.pipe(mapToComponents(labelComponent, 'id')));
+    expect(lastRender(collected).map(el => el.textContent)).toEqual(['a', 'b']);
+  });
+
+  it('reuses the same element instance for a stable id across updates', () => {
+    const source = new BehaviorSubject<Item[]>([{ id: 1, label: 'a' }]);
+    const collected = collect(source.pipe(mapToComponents(labelComponent, 'id')));
+    const original = lastRender(collected)[0];
+
+    source.next([{ id: 1, label: 'a' }, { id: 2, label: 'b' }]); // add a sibling
+    expect(lastRender(collected)[0]).toBe(original); // same element reused, not recreated
+  });
+
+  it('keeps an existing item component live after a later array change', () => {
+    const source = new BehaviorSubject<Item[]>([{ id: 1, label: 'a' }]);
+    const collected = collect(source.pipe(mapToComponents(labelComponent, 'id')));
+    const element = lastRender(collected)[0];
+
+    source.next([{ id: 1, label: 'a' }, { id: 2, label: 'b' }]); // unrelated change (add)
+    source.next([{ id: 1, label: 'A' }, { id: 2, label: 'b' }]); // update item 1
+
+    expect(element.textContent).toBe('A'); // the reused element still reacts to its item observable
+  });
+
+  it('reorders existing elements to match the new order, reusing them', () => {
+    const source = new BehaviorSubject<Item[]>([
+      { id: 1, label: 'a' },
+      { id: 2, label: 'b' },
+    ]);
+    const collected = collect(source.pipe(mapToComponents(labelComponent, 'id')));
+    const [first, second] = lastRender(collected);
+
+    source.next([{ id: 2, label: 'b' }, { id: 1, label: 'a' }]);
+
+    const reordered = lastRender(collected);
+    expect(reordered).toEqual([second, first]); // same instances, swapped order
+  });
+
+  it('removes elements and tears down their components when items leave', () => {
+    const teardowns: number[] = [];
+    const creation = (item$: Observable<Item>) => {
+      let id: number;
+      return Div(item$.pipe(map(item => { id = item.id; return item.label; }))).pipe(
+        finalize(() => teardowns.push(id)),
+      );
+    };
+    const source = new BehaviorSubject<Item[]>([
+      { id: 1, label: 'a' },
+      { id: 2, label: 'b' },
+    ]);
+    const collected = collect(source.pipe(mapToComponents(creation, 'id')));
+
+    source.next([{ id: 1, label: 'a' }]); // drop item 2
+
+    expect(lastRender(collected).map(el => el.textContent)).toEqual(['a']);
+    expect(teardowns).toEqual([2]);
+  });
+
+  it('uses the array index as the id by default', () => {
+    const source = new BehaviorSubject([{ id: 1, label: 'a' }, { id: 2, label: 'b' }]);
+    const collected = collect(source.pipe(mapToComponents(labelComponent)));
+    const [first, second] = lastRender(collected);
+
+    // Same positions keep the same elements even though the items (and ids) differ.
+    source.next([{ id: 9, label: 'x' }, { id: 8, label: 'y' }]);
+    const updated = lastRender(collected);
+    expect(updated[0]).toBe(first);
+    expect(updated[1]).toBe(second);
+    expect(updated.map(el => el.textContent)).toEqual(['x', 'y']);
+  });
+
+  it('derives the id from a function', () => {
+    const source = new BehaviorSubject<Item[]>([{ id: 1, label: 'a' }]);
+    const collected = collect(source.pipe(mapToComponents(labelComponent, item => item.id)));
+    const element = lastRender(collected)[0];
+
+    source.next([{ id: 1, label: 'a' }, { id: 2, label: 'b' }]);
+    expect(lastRender(collected)[0]).toBe(element); // matched by id-from-function
+  });
+
+  it('errors if the id function returns a non string/number', () => {
+    const source = new BehaviorSubject<Item[]>([{ id: 1, label: 'a' }]);
+    let error: unknown;
+    source
+      .pipe(mapToComponents(labelComponent, (() => ({})) as never))
+      .subscribe({ next: () => undefined, error: caught => { error = caught; } });
+    expect(error).toBeInstanceOf(TypeError);
+  });
+});

--- a/src/lib/rxfm/operator-isolation-service.test.ts
+++ b/src/lib/rxfm/operator-isolation-service.test.ts
@@ -1,0 +1,53 @@
+import { TestOperatorIsolationService } from './operator-isolation-service';
+import { ChildrenBlockMetadata } from './children/children-operator-isolation';
+
+describe('OperatorIsolationService', () => {
+  let service: TestOperatorIsolationService;
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    service = new TestOperatorIsolationService();
+    element = document.createElement('div');
+  });
+
+  it('has no metadata for an untouched element', () => {
+    expect(service.inspectMetadata(element)).toBeUndefined();
+  });
+
+  it('lazily creates metadata on first access', () => {
+    service.getStylesMap(element);
+    expect(service.inspectMetadata(element)).toBeDefined();
+  });
+
+  it('returns stable map instances across calls for the same element', () => {
+    expect(service.getStylesMap(element)).toBe(service.getStylesMap(element));
+    expect(service.getAttributesMap(element)).toBe(service.getAttributesMap(element));
+    expect(service.getClassesMap(element)).toBe(service.getClassesMap(element));
+  });
+
+  it('starts each metadata collection empty', () => {
+    expect(service.getStylesMap(element).size).toBe(0);
+    expect(service.getAttributesMap(element).size).toBe(0);
+    expect(service.getClassesMap(element).size).toBe(0);
+    expect(service.getChildrenMetadata(element)).toEqual([]);
+  });
+
+  it('round-trips children metadata through get/set', () => {
+    const children: ChildrenBlockMetadata[] = [{ symbol: Symbol(), length: 2 }];
+    service.setChildrenMetadata(element, children);
+    expect(service.getChildrenMetadata(element)).toBe(children);
+  });
+
+  it('keeps metadata for different elements isolated', () => {
+    const other = document.createElement('span');
+    service.getStylesMap(element).set(Symbol(), {});
+    expect(service.getStylesMap(other).size).toBe(0);
+    expect(service.getStylesMap(element).size).toBe(1);
+  });
+
+  it('persists mutations to a returned map', () => {
+    const symbol = Symbol();
+    service.getAttributesMap(element).set(symbol, { id: 'x' });
+    expect(service.getAttributesMap(element).get(symbol)).toEqual({ id: 'x' });
+  });
+});

--- a/src/lib/rxfm/utils/destroySubject.test.ts
+++ b/src/lib/rxfm/utils/destroySubject.test.ts
@@ -1,0 +1,29 @@
+import { Subject } from 'rxjs';
+import { DestroySubject } from './destroySubject';
+
+// DestroySubject is deprecated but still shipped; these lock in its behaviour.
+describe('DestroySubject', () => {
+  it('completes an untilDestroy source when destroyed', () => {
+    const destroy = new DestroySubject();
+    const source = new Subject<number>();
+    const values: number[] = [];
+    let completed = false;
+    destroy.untilDestroy(source).subscribe({
+      next: value => values.push(value),
+      complete: () => { completed = true; },
+    });
+
+    source.next(1);
+    destroy.destroy();
+    source.next(2); // ignored — the source has been unsubscribed by takeUntil
+
+    expect(values).toEqual([1]);
+    expect(completed).toBe(true);
+  });
+
+  it('emits (and replays) a value when destroyed', async () => {
+    const destroy = new DestroySubject();
+    destroy.destroy();
+    await expect(destroy.toPromise()).resolves.toBeUndefined(); // replay of the completion value
+  });
+});

--- a/src/lib/rxfm/utils/utils.test.ts
+++ b/src/lib/rxfm/utils/utils.test.ts
@@ -1,0 +1,272 @@
+import { BehaviorSubject, Observable, of, Subject, Subscription } from 'rxjs';
+import {
+  coerceToObservable,
+  coerceToArray,
+  flatten,
+  recursiveFlatten,
+  select,
+  selectFrom,
+  destructure,
+  watch,
+  using,
+  access,
+  conditional,
+  reuse,
+  not,
+  and,
+  nand,
+  or,
+  nor,
+  equals,
+  log,
+  switchTap,
+} from './utils';
+
+/** Subscribe to an observable and collect its synchronous emissions into an array. */
+function collect<T>(observable: Observable<T>): { values: T[]; subscription: Subscription } {
+  const values: T[] = [];
+  const subscription = observable.subscribe(value => values.push(value));
+  return { values, subscription };
+}
+
+describe('coerceToObservable', () => {
+  it('wraps a plain value in an observable', () => {
+    expect(collect(coerceToObservable(5)).values).toEqual([5]);
+  });
+
+  it('passes an observable through unchanged', () => {
+    const source = of(5);
+    expect(coerceToObservable(source)).toBe(source);
+  });
+});
+
+describe('coerceToArray', () => {
+  it('wraps a plain value in an array', () => {
+    expect(coerceToArray(5)).toEqual([5]);
+  });
+
+  it('passes an array through unchanged', () => {
+    const array = [1, 2];
+    expect(coerceToArray(array)).toBe(array);
+  });
+});
+
+describe('flatten', () => {
+  it('flattens one level, leaving scalars in place', () => {
+    expect(flatten([1, [2, 3], 4])).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('recursiveFlatten', () => {
+  it('flattens arbitrarily nested arrays', () => {
+    expect(recursiveFlatten([1, [2, [3, [4]]], 5])).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('wraps a bare scalar', () => {
+    expect(recursiveFlatten(5)).toEqual([5]);
+  });
+});
+
+describe('select', () => {
+  it('emits the selected key and only re-emits when it changes', () => {
+    const source = new BehaviorSubject({ a: 1, b: 1 });
+    const { values } = collect(source.pipe(select('a')));
+    source.next({ a: 1, b: 2 }); // a unchanged → no emission
+    source.next({ a: 2, b: 2 }); // a changed → emits
+    expect(values).toEqual([1, 2]);
+  });
+
+  it('selects nested keys', () => {
+    const source = of({ a: { b: { c: 7 } } });
+    expect(collect(source.pipe(select('a', 'b', 'c'))).values).toEqual([7]);
+  });
+});
+
+describe('selectFrom', () => {
+  it('selects a key from a source observable', () => {
+    const source = new BehaviorSubject({ a: 1 });
+    const { values } = collect(selectFrom(source, 'a'));
+    source.next({ a: 1 }); // unchanged
+    source.next({ a: 5 });
+    expect(values).toEqual([1, 5]);
+  });
+});
+
+describe('destructure', () => {
+  it('exposes each property as its own distinct observable', () => {
+    const source = new BehaviorSubject({ a: 1, b: 2 });
+    const { a, b } = destructure(source);
+    const collectedA = collect(a);
+    const collectedB = collect(b);
+    source.next({ a: 1, b: 3 }); // only b changes
+    expect(collectedA.values).toEqual([1]);
+    expect(collectedB.values).toEqual([2, 3]);
+  });
+});
+
+describe('watch', () => {
+  it('maps the source and only emits distinct results', () => {
+    const source = new BehaviorSubject(2);
+    const { values } = collect(source.pipe(watch(n => n % 2)));
+    source.next(4); // 4 % 2 === 0, same as before → no emission
+    source.next(5); // 5 % 2 === 1 → emits
+    expect(values).toEqual([0, 1]);
+  });
+});
+
+describe('using', () => {
+  it('maps emissions through the action, emitting distinct results', () => {
+    const source = new BehaviorSubject(1);
+    const { values } = collect(using(source, n => n * 10));
+    source.next(1); // unchanged
+    source.next(2);
+    expect(values).toEqual([10, 20]);
+  });
+});
+
+describe('access', () => {
+  it('reads a key (observable) from a static object', () => {
+    const value = { a: 1, b: 2 };
+    const key = new BehaviorSubject<keyof typeof value>('a');
+    const { values } = collect(access(value, key));
+    key.next('b');
+    expect(values).toEqual([1, 2]);
+  });
+
+  it('reads a static key from an object observable', () => {
+    const value = new BehaviorSubject({ a: 1, b: 2 });
+    const { values } = collect(access(value, 'a'));
+    value.next({ a: 9, b: 2 });
+    expect(values).toEqual([1, 9]);
+  });
+});
+
+describe('conditional', () => {
+  it('switches between then/else as the source toggles', () => {
+    const source = new BehaviorSubject<boolean>(true);
+    const { values } = collect(conditional(source, 'yes', 'no'));
+    source.next(false);
+    source.next(true);
+    expect(values).toEqual(['yes', 'no', 'yes']);
+  });
+
+  it('defaults the else branch to undefined', () => {
+    const source = new BehaviorSubject<boolean>(false);
+    expect(collect(conditional(source, 'yes')).values).toEqual([undefined]);
+  });
+
+  it('accepts observable then/else values', () => {
+    const source = new BehaviorSubject<boolean>(true);
+    const then = new BehaviorSubject('a');
+    const { values } = collect(conditional(source, then, of('b')));
+    then.next('a2'); // active branch updates
+    source.next(false);
+    expect(values).toEqual(['a', 'a2', 'b']);
+  });
+
+  it('supports the deprecated options-object form', () => {
+    const source = new BehaviorSubject<boolean>(true);
+    const { values } = collect(conditional({ if: source, then: 'yes', else: 'no' }));
+    source.next(false);
+    expect(values).toEqual(['yes', 'no']);
+  });
+});
+
+describe('reuse', () => {
+  it('shares a single subscription among subscribers', () => {
+    let subscribeCount = 0;
+    const shared = reuse(new Observable<number>(observer => {
+      subscribeCount++;
+      observer.next(1);
+    }));
+    collect(shared);
+    collect(shared);
+    expect(subscribeCount).toBe(1);
+  });
+});
+
+describe('boolean logic', () => {
+  it('not inverts truthiness', () => {
+    expect(collect(not(of(0))).values).toEqual([true]);
+    expect(collect(not(of('x'))).values).toEqual([false]);
+  });
+
+  it('and emits true only when all sources are truthy', () => {
+    const a = new BehaviorSubject<unknown>(1);
+    const b = new BehaviorSubject<unknown>(1);
+    const { values } = collect(and(a, b));
+    b.next(0);
+    expect(values).toEqual([true, false]);
+  });
+
+  it('or emits true when any source is truthy', () => {
+    const a = new BehaviorSubject<unknown>(0);
+    const b = new BehaviorSubject<unknown>(0);
+    const { values } = collect(or(a, b));
+    b.next(1);
+    expect(values).toEqual([false, true]);
+  });
+
+  it('nand is the negation of and', () => {
+    expect(collect(nand(of(1), of(1))).values).toEqual([false]);
+    expect(collect(nand(of(1), of(0))).values).toEqual([true]);
+  });
+
+  it('nor is the negation of or', () => {
+    expect(collect(nor(of(0), of(0))).values).toEqual([true]);
+    expect(collect(nor(of(1), of(0))).values).toEqual([false]);
+  });
+});
+
+describe('equals', () => {
+  it('emits whether all sources are equal, mixing static and observable inputs', () => {
+    const a = new BehaviorSubject(1);
+    const { values } = collect(equals(a, 1));
+    a.next(2);
+    a.next(1);
+    expect(values).toEqual([true, false, true]);
+  });
+});
+
+describe('log', () => {
+  let spy: jest.SpyInstance;
+  beforeEach(() => { spy = jest.spyOn(console, 'log').mockImplementation(() => undefined); });
+  afterEach(() => { spy.mockRestore(); });
+
+  it('mirrors the source unchanged', () => {
+    expect(collect(of(3).pipe(log())).values).toEqual([3]);
+  });
+
+  it('logs with a string prefix', () => {
+    collect(of(3).pipe(log('value:')));
+    expect(spy).toHaveBeenCalledWith('value:', 3);
+  });
+
+  it('logs the result of a formatter function', () => {
+    collect(of(3).pipe(log<number>(v => `got ${v}`)));
+    expect(spy).toHaveBeenCalledWith('got 3');
+  });
+});
+
+describe('switchTap', () => {
+  it('mirrors the source and ignores the effect observable emissions', () => {
+    const source = new BehaviorSubject('a');
+    const effect = new Subject<string>();
+    const { values } = collect(source.pipe(switchTap(() => effect)));
+    effect.next('ignored');
+    source.next('b');
+    expect(values).toEqual(['a', 'b']);
+  });
+
+  it('runs the effect for each distinct source emission', () => {
+    const source = new BehaviorSubject('a');
+    const seen: string[] = [];
+    collect(source.pipe(switchTap(value => {
+      seen.push(value);
+      return of(null);
+    })));
+    source.next('a'); // distinct guard → effect not re-run
+    source.next('b');
+    expect(seen).toEqual(['a', 'b']);
+  });
+});

--- a/src/lib/rxfm/utils/utils.ts
+++ b/src/lib/rxfm/utils/utils.ts
@@ -1,5 +1,13 @@
 import { combineLatest, MonoTypeOperatorFunction, Observable, of, OperatorFunction } from "rxjs";
-import { distinctUntilChanged, ignoreElements, map, pluck, shareReplay, startWith, switchMap, tap } from "rxjs/operators";
+import { distinctUntilChanged, ignoreElements, map, shareReplay, startWith, switchMap, tap } from "rxjs/operators";
+
+/**
+ * Read a (possibly nested) sequence of keys from a value, short-circuiting to `undefined` if an
+ * intermediate value is nullish. Replaces RxJS's deprecated `pluck` operator.
+ */
+function pluckKeys(value: unknown, keys: string[]): unknown {
+  return keys.reduce<any>((accumulator, key) => accumulator?.[key], value);
+}
 
 export function coerceToObservable<T>(value: T | Observable<T>): Observable<T> {
   return value instanceof Observable ? value : of(value);
@@ -42,7 +50,7 @@ export function select<T, K0 extends keyof T, K1 extends keyof T[K0], K2 extends
 export function select<T>(...keys: string[]): OperatorFunction<T, any> {
   return (input: Observable<T>) => input.pipe(
     distinctUntilChanged(),
-    pluck(...keys),
+    map(value => pluckKeys(value, keys)),
     distinctUntilChanged(),
   );
 }
@@ -59,7 +67,7 @@ export function selectFrom<T>(
 ): Observable<any> {
   return input.pipe(
     distinctUntilChanged(),
-    pluck(...keys),
+    map(value => pluckKeys(value, keys)),
     distinctUntilChanged(),
   );
 }


### PR DESCRIPTION
Adds unit-test coverage across the library and fixes several issues surfaced along the way. Independent of the tsrx/docs branches — pure library work off `master`.

## Test coverage: ~21 → 138 tests

Every substantive module is now covered:

- **`child-differ`** — adds/removes/reorders + an exhaustive permutation sweep replayed against a real DOM parent
- **`utils`** — all exports (`select`/`selectFrom`/`destructure`/`watch`/`using`/`access`/`conditional`/`reuse`/boolean logic/`equals`/`log`/`switchTap`/coercion)
- **`map-to-components`** — ordering, element reuse, live updates after later array changes, reorder, removal teardown, id-by-index/prop/function, invalid-id error
- **operator isolation** — children block metadata helpers, the attribute priority/coercion engine, and `OperatorIsolationService`
- **`classes` / `styles` / `attributes`** — static/observable/tagged-template/removal/diffing/cross-operator isolation, rendered onto real elements
- **`events`** — proxy + generic forms, observable handlers, type filtering, the `events` map
- **`children`** — full coercion matrix (strings, numbers, null/false, components, functions, observable text + element arrays) and DOM patching/ordering
- **component factories** — deferred per-subscription element, `componentOperator` passthrough, `sideEffect`, `componentCreator` array rejection
- **`addToView`** and the deprecated `DestroySubject`

## Bug fixes

1. **`childDiffer` keyed reordering** — the old heuristic compared each node only to its old successor, so it could keep nodes that had actually swapped relative order (e.g. `[A,B,C] → [C,A,B]` produced `[A,C,B]`), plus a falsy-zero bug ignored a node moving to index 0. Replaced with the standard LIS-based keyed diff: keep the longest already-in-order run in place and move the rest — correct and minimal in DOM operations, O(n log n). Adds/removes/truncations were unaffected.
2. **`addChildrenToMetadata`** — the block index was read from `currentMetadata` but used to index `newMetadata`, so a block registered within the call gave index `-1` and threw. Now derived from `newMetadata`. Masked in practice because callers pre-register; covered by a regression test.
3. **`setStyle` change-guard** — `element.style[key] || null !== value || null` parsed (by precedence) as `style[key] || (null !== value) || null`, effectively always truthy when a value is present, defeating the intended "only write when changed" check. Rewritten as `(element.style[key] || null) !== nextValue`.
4. **`select`/`selectFrom`** — replaced RxJS's deprecated `pluck` operator with an equivalent `map`-based key accessor (behaviour unchanged, now tested).

## Investigated, no change needed

- **`mapToComponents` `switchMap`** — looked like it might tear down live components on each diff; it's actually correct (the downstream `mergeAll` owns the long-lived subscriptions). Confirmed with a lifecycle probe, then locked in with tests.

## Verification

`yarn test` (138 passing) · `yarn lint` clean · `yarn build` (library) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)